### PR TITLE
[codex] Add remote signer sign-in options

### DIFF
--- a/web/src/lib/components/Header.svelte
+++ b/web/src/lib/components/Header.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 import { page } from "$app/stores";
 import { getCurrentUser } from "$lib/current_user.svelte";
-import { signin, signout } from "$lib/utils/auth";
-import { Key, SignIn, SignOut } from "phosphor-svelte";
+import SignInMenu from "$lib/components/SignInMenu.svelte";
+import { signout } from "$lib/utils/auth";
+import { Key, SignOut } from "phosphor-svelte";
 
 const user = $derived(getCurrentUser()?.user);
 const activePage = $derived($page.url.pathname);
@@ -33,13 +34,7 @@ const activePage = $derived($page.url.pathname);
                 Sign out
             </button>
         {:else}
-            <button
-                onclick={() => signin()}
-                class="button button-primary button-icon"
-            >
-                <SignIn size="20" />
-                Sign in
-            </button>
+            <SignInMenu />
         {/if}
     </nav>
 </div>

--- a/web/src/lib/components/SignInMenu.svelte
+++ b/web/src/lib/components/SignInMenu.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+import {
+    createNostrConnectSigninSession,
+    hasNip07Extension,
+    isAmberSigninSupported,
+    type NostrConnectSigninSession,
+} from "$lib/nostr";
+import {
+    completeSignin,
+    signin,
+    type SigninMethod,
+    type SigninOptions,
+} from "$lib/utils/auth";
+import {
+    Browser,
+    Check,
+    Cloud,
+    Copy,
+    DeviceMobile,
+    LinkSimple,
+    SignIn,
+    X,
+} from "phosphor-svelte";
+
+type BusyState = SigninMethod | "nostr-connect-link" | null;
+
+let open = $state(false);
+let bunkerUri = $state("");
+let busy: BusyState = $state(null);
+let extensionAvailable = $state(false);
+let amberAvailable = $state(false);
+let connectUri = $state("");
+let connectError = $state<string | null>(null);
+let connectCopied = $state(false);
+let connectSession: NostrConnectSigninSession | null = null;
+let connectController: AbortController | null = null;
+const signinOptionClass =
+    "flex w-full items-center gap-3 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-3 text-left text-gray-100 hover:border-indigo-400/50 hover:bg-white/[0.06] disabled:cursor-not-allowed disabled:opacity-50";
+
+$effect(() => {
+    if (open) {
+        extensionAvailable = hasNip07Extension();
+        amberAvailable = isAmberSigninSupported();
+    }
+});
+
+function openMenu() {
+    open = true;
+}
+
+function closeMenu() {
+    cancelConnectLink();
+    open = false;
+    bunkerUri = "";
+    connectError = null;
+    busy = null;
+}
+
+async function runSignin(method: SigninMethod, options: SigninOptions = {}) {
+    busy = method;
+    const user = await signin(method, options);
+    busy = null;
+
+    if (user) {
+        closeMenu();
+    }
+}
+
+async function submitBunker(event: SubmitEvent) {
+    event.preventDefault();
+    await runSignin("nip46-bunker", { bunkerUri });
+}
+
+async function startConnectLink() {
+    cancelConnectLink();
+    connectError = null;
+    connectCopied = false;
+    connectSession = createNostrConnectSigninSession();
+    connectUri = connectSession.uri;
+
+    const controller = new AbortController();
+    connectController = controller;
+    busy = "nostr-connect-link";
+
+    try {
+        const user = await connectSession.waitForUser(controller.signal);
+        const signedInUser = await completeSignin(user);
+        if (signedInUser) {
+            closeMenu();
+        }
+    } catch (error) {
+        if (!controller.signal.aborted) {
+            connectError =
+                error instanceof Error ? error.message : "Unable to connect signer";
+        }
+    } finally {
+        if (connectController === controller) {
+            busy = null;
+            connectController = null;
+        }
+    }
+}
+
+function cancelConnectLink() {
+    connectController?.abort();
+    connectSession?.cancel();
+    connectController = null;
+    connectSession = null;
+    connectUri = "";
+    connectError = null;
+}
+
+async function copyConnectUri() {
+    if (!connectUri) return;
+
+    await navigator.clipboard.writeText(connectUri);
+    connectCopied = true;
+    setTimeout(() => {
+        connectCopied = false;
+    }, 1500);
+}
+</script>
+
+<button type="button" onclick={openMenu} class="button button-primary button-icon">
+    <SignIn size="20" />
+    Sign in
+</button>
+
+{#if open}
+    <div class="fixed inset-0 z-50 flex items-start justify-center bg-black/60 px-4 py-8 md:items-center">
+        <div
+            class="w-full max-w-lg rounded-lg border border-white/15 bg-gray-900 shadow-2xl shadow-black/40"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="signin-title"
+        >
+            <div class="flex items-center justify-between border-b border-white/10 px-5 py-4">
+                <div>
+                    <h2 id="signin-title" class="text-lg font-semibold">Sign in</h2>
+                    <p class="text-sm text-gray-400">Choose a signer</p>
+                </div>
+                <button
+                    type="button"
+                    onclick={closeMenu}
+                    class="rounded-md p-1 text-gray-400 hover:bg-white/10 hover:text-white"
+                    aria-label="Close sign-in options"
+                >
+                    <X size="20" />
+                </button>
+            </div>
+
+            <div class="flex flex-col gap-3 p-5">
+                <button
+                    type="button"
+                    onclick={() => runSignin("extension")}
+                    disabled={busy !== null}
+                    class={signinOptionClass}
+                >
+                    <Browser size="24" />
+                    <span class="min-w-0 flex-1">
+                        <span class="block font-medium">Browser extension</span>
+                        <span class="block text-xs text-gray-400">
+                            {extensionAvailable ? "NIP-07 detected" : "NIP-07 extension"}
+                        </span>
+                    </span>
+                    <span class="text-xs text-gray-500">
+                        {busy === "extension" ? "Opening" : "NIP-07"}
+                    </span>
+                </button>
+
+                <div class="rounded-lg border border-white/10 bg-white/[0.03] p-3">
+                    <div class="mb-3 flex items-center gap-3">
+                        <Cloud size="24" class="text-indigo-300" />
+                        <div>
+                            <h3 class="font-medium">Remote signer</h3>
+                            <p class="text-xs text-gray-400">Nostr Connect</p>
+                        </div>
+                    </div>
+
+                    <form class="flex flex-col gap-2 sm:flex-row" onsubmit={submitBunker}>
+                        <input
+                            class="min-w-0 flex-1"
+                            type="text"
+                            bind:value={bunkerUri}
+                            placeholder="bunker://..."
+                            autocapitalize="off"
+                            autocomplete="off"
+                            spellcheck="false"
+                        />
+                        <button
+                            type="submit"
+                            class="button button-primary"
+                            disabled={!bunkerUri.trim() || busy !== null}
+                        >
+                            {busy === "nip46-bunker" ? "Connecting" : "Connect"}
+                        </button>
+                    </form>
+
+                    <div class="mt-3 flex flex-wrap items-center gap-2">
+                        {#if connectUri}
+                            <a href={connectUri} class="button button-secondary button-icon">
+                                <LinkSimple size="18" />
+                                Open
+                            </a>
+                            <button
+                                type="button"
+                                class="button button-secondary button-icon"
+                                onclick={copyConnectUri}
+                            >
+                                {#if connectCopied}
+                                    <Check size="18" />
+                                {:else}
+                                    <Copy size="18" />
+                                {/if}
+                                Copy
+                            </button>
+                            <button
+                                type="button"
+                                class="button button-secondary"
+                                onclick={cancelConnectLink}
+                            >
+                                Cancel
+                            </button>
+                        {:else}
+                            <button
+                                type="button"
+                                class="button button-secondary button-icon"
+                                onclick={startConnectLink}
+                                disabled={busy !== null}
+                            >
+                                <LinkSimple size="18" />
+                                Create connect link
+                            </button>
+                        {/if}
+                    </div>
+
+                    {#if connectUri}
+                        <input
+                            class="mt-3 w-full font-mono text-xs"
+                            type="text"
+                            readonly
+                            value={connectUri}
+                            onclick={(event) => event.currentTarget.select()}
+                        />
+                    {/if}
+
+                    {#if connectError}
+                        <p class="mt-2 text-sm text-red-300">{connectError}</p>
+                    {/if}
+                </div>
+
+                <button
+                    type="button"
+                    onclick={() => runSignin("amber")}
+                    disabled={busy !== null || !amberAvailable}
+                    class={signinOptionClass}
+                >
+                    <DeviceMobile size="24" />
+                    <span class="min-w-0 flex-1">
+                        <span class="block font-medium">Amber</span>
+                        <span class="block text-xs text-gray-400">
+                            {amberAvailable ? "Android signer ready" : "Android signer"}
+                        </span>
+                    </span>
+                    <span class="text-xs text-gray-500">
+                        {busy === "amber" ? "Opening" : "NIP-55"}
+                    </span>
+                </button>
+            </div>
+        </div>
+    </div>
+{/if}

--- a/web/src/lib/current_user.svelte.ts
+++ b/web/src/lib/current_user.svelte.ts
@@ -7,7 +7,7 @@ import {
 let currentUser: CurrentUser | null = $state(null);
 
 class CurrentUser {
-    /** The Nostr user currently signed in through NIP-07. */
+    /** The Nostr user currently signed in through a browser, remote, or Android signer. */
     user: NostrUser | null = $state(null);
 
     /** Array of pubkeys that the current user follows */

--- a/web/src/lib/keycast_api.svelte.ts
+++ b/web/src/lib/keycast_api.svelte.ts
@@ -3,11 +3,10 @@ import { getContext, setContext } from "svelte";
 import { signNostrEvent } from "./nostr";
 import {
     buildNip98Tags,
+    NIP_98_HTTP_AUTH_KIND,
     normalizeApiBaseUrl,
     type HttpAuthMethod,
 } from "./utils/http_auth";
-
-const NIP_98_HTTP_AUTH_KIND = 27235;
 
 export class KeycastApi {
     private baseUrl: string;

--- a/web/src/lib/nostr.ts
+++ b/web/src/lib/nostr.ts
@@ -7,12 +7,19 @@ import type {
 import { normalizeToPubkey, npubEncode } from "applesauce-core/helpers";
 import { createEventLoaderForStore } from "applesauce-loaders/loaders";
 import { RelayPool } from "applesauce-relay";
-import { ExtensionSigner } from "applesauce-signers";
+import type { ISigner } from "applesauce-signers";
+import {
+    AmberClipboardSigner,
+    ExtensionSigner,
+    NostrConnectSigner,
+} from "applesauce-signers";
 import { catchError, filter, firstValueFrom, of, timeout } from "rxjs";
 import {
     DEFAULT_NOSTR_READ_RELAYS,
     DEFAULT_OUTBOX_RELAYS,
+    REQUIRED_PUBLIC_RELAYS,
 } from "$lib/utils/relays";
+import { NIP_98_HTTP_AUTH_KIND } from "./utils/http_auth";
 
 export type NostrUser = {
     pubkey: string;
@@ -20,12 +27,30 @@ export type NostrUser = {
 };
 
 export type NostrProfile = ProfileContent;
+export type SignerKind = "extension" | "nostr-connect" | "amber";
+export type ActiveSignerSummary = {
+    kind: SignerKind;
+    pubkey: string;
+};
+export type ActiveSigner = ActiveSignerSummary & {
+    signer: ISigner;
+};
+export type NostrConnectSigninSession = {
+    uri: string;
+    waitForUser: (abort?: AbortSignal) => Promise<NostrUser>;
+    cancel: () => void;
+};
 
 const PROFILE_LOAD_TIMEOUT_MS = 5000;
 const CONTACTS_LOAD_TIMEOUT_MS = 5000;
+export const DEFAULT_NOSTR_CONNECT_RELAYS = [
+    "wss://relay.nsec.app",
+    ...REQUIRED_PUBLIC_RELAYS,
+] as const;
 
 export const eventStore = new EventStore();
 export const relayPool = new RelayPool();
+let activeSigner: ActiveSigner | null = null;
 
 const loaderRelays = Array.from(
     new Set([...DEFAULT_NOSTR_READ_RELAYS, ...DEFAULT_OUTBOX_RELAYS]),
@@ -69,6 +94,23 @@ export function hasNip07Extension(): boolean {
     return typeof window !== "undefined" && !!window.nostr;
 }
 
+export function isAmberSigninSupported(): boolean {
+    return Boolean(AmberClipboardSigner.SUPPORTED);
+}
+
+export function normalizeBunkerUri(uri: string): string {
+    const normalized = uri.trim();
+    if (!normalized.toLowerCase().startsWith("bunker://")) {
+        throw new Error("Paste a bunker:// remote signer connection string");
+    }
+
+    return normalized;
+}
+
+export function buildNip46SigningPermissions(): string[] {
+    return NostrConnectSigner.buildSigningPermissions([NIP_98_HTTP_AUTH_KIND]);
+}
+
 export function getExtensionSigner(): ExtensionSigner {
     if (!hasNip07Extension()) {
         throw new Error("Install or enable a NIP-07 browser extension to sign in");
@@ -86,24 +128,155 @@ export async function getExtensionPubkey(): Promise<string> {
     return pubkey;
 }
 
+export async function getExtensionUser(): Promise<NostrUser> {
+    return userFromSigner(getExtensionSigner(), "extension");
+}
+
+export async function getAmberUser(): Promise<NostrUser> {
+    return userFromSigner(new AmberClipboardSigner(), "amber");
+}
+
+export async function connectNostrConnectBunker(
+    bunkerUri: string,
+): Promise<NostrUser> {
+    const signer = await NostrConnectSigner.fromBunkerURI(normalizeBunkerUri(bunkerUri), {
+        pool: relayPool,
+        permissions: buildNip46SigningPermissions(),
+        onAuth: openSignerAuthChallenge,
+    });
+
+    return userFromSigner(signer, "nostr-connect");
+}
+
+export function createNostrConnectSigninSession(
+    relays: readonly string[] = DEFAULT_NOSTR_CONNECT_RELAYS,
+): NostrConnectSigninSession {
+    const signer = new NostrConnectSigner({
+        relays: [...relays],
+        pool: relayPool,
+        onAuth: openSignerAuthChallenge,
+    });
+    const uri = signer.getNostrConnectURI({
+        name: "Keycast",
+        url: browserOrigin(),
+        permissions: buildNip46SigningPermissions(),
+    });
+
+    return {
+        uri,
+        waitForUser: async (abort?: AbortSignal) => {
+            await signer.waitForSigner(abort);
+            return userFromSigner(signer, "nostr-connect");
+        },
+        cancel: () => {
+            void signer.close();
+        },
+    };
+}
+
+export function setActiveSigner(next: ActiveSigner): ActiveSigner {
+    const pubkey = normalizePubkey(next.pubkey);
+    if (!pubkey) {
+        throw new Error("Signer returned an invalid pubkey");
+    }
+
+    if (activeSigner?.signer !== next.signer) {
+        disposeSigner(activeSigner?.signer);
+    }
+
+    activeSigner = {
+        kind: next.kind,
+        pubkey,
+        signer: next.signer,
+    };
+    return activeSigner;
+}
+
+export function clearActiveSigner(): void {
+    disposeSigner(activeSigner?.signer);
+    activeSigner = null;
+}
+
+export function getActiveSignerSummary(): ActiveSignerSummary | null {
+    if (!activeSigner) return null;
+
+    return {
+        kind: activeSigner.kind,
+        pubkey: activeSigner.pubkey,
+    };
+}
+
 export async function signNostrEvent(
     template: EventTemplate,
     expectedPubkey?: string,
 ): Promise<NostrEvent> {
-    const signer = getExtensionSigner();
-    const signedEvent = await signer.signEvent(template);
+    const signer = activeSigner?.signer ?? getExtensionSigner();
     const normalizedExpectedPubkey = expectedPubkey
         ? normalizePubkey(expectedPubkey)
         : null;
 
     if (
+        activeSigner &&
+        normalizedExpectedPubkey &&
+        activeSigner.pubkey !== normalizedExpectedPubkey
+    ) {
+        throw new Error("The active signer is connected to a different pubkey");
+    }
+
+    const signedEvent = await signer.signEvent(template);
+
+    if (
         normalizedExpectedPubkey &&
         normalizePubkey(signedEvent.pubkey) !== normalizedExpectedPubkey
     ) {
-        throw new Error("The NIP-07 extension signed with a different pubkey");
+        throw new Error("The signer signed with a different pubkey");
     }
 
     return signedEvent;
+}
+
+async function userFromSigner(signer: ISigner, kind: SignerKind): Promise<NostrUser> {
+    const pubkey = normalizePubkey(await signer.getPublicKey());
+    if (!pubkey) {
+        throw new Error("The signer did not return a valid pubkey");
+    }
+
+    const user = userFromPubkey(pubkey);
+    if (!user) {
+        throw new Error("The signer did not return a valid pubkey");
+    }
+
+    setActiveSigner({ kind, signer, pubkey });
+    return user;
+}
+
+function disposeSigner(signer: ISigner | null | undefined): void {
+    const disposable = signer as
+        | {
+              close?: () => Promise<void> | void;
+              destroy?: () => void;
+          }
+        | null
+        | undefined;
+
+    if (disposable?.close) void disposable.close();
+    disposable?.destroy?.();
+}
+
+function openSignerAuthChallenge(url: string): Promise<void> {
+    if (typeof window !== "undefined") {
+        window.open(
+            url,
+            "keycast-signer-auth",
+            "width=420,height=640,resizable=yes,status=no,location=yes,toolbar=no,menubar=no",
+        );
+    }
+
+    return Promise.resolve();
+}
+
+function browserOrigin(): string | undefined {
+    return typeof location === "undefined" ? undefined : location.origin;
 }
 
 export async function loadProfile(

--- a/web/src/lib/utils/auth.ts
+++ b/web/src/lib/utils/auth.ts
@@ -1,32 +1,49 @@
 import { goto } from "$app/navigation";
 import { getCurrentUser, setCurrentUser } from "$lib/current_user.svelte";
 import {
-    getExtensionPubkey,
-    hasNip07Extension,
-    userFromPubkey,
+    clearActiveSigner,
+    connectNostrConnectBunker,
+    getAmberUser,
+    getExtensionUser,
+    isAmberSigninSupported,
     type NostrUser,
 } from "$lib/nostr";
 import toast from "svelte-hot-french-toast";
 import { checkPubkeyAllowed } from "./allowlist";
 
+export type SigninMethod = "extension" | "nip46-bunker" | "amber";
+export type SigninOptions = {
+    bunkerUri?: string;
+};
+
 async function isAllowedPubkey(pubkey: string) {
     return checkPubkeyAllowed(pubkey);
 }
 
-export async function signin(): Promise<NostrUser | null> {
-    const signedInUser = await userFromNip07();
+export async function signin(
+    method: SigninMethod = "extension",
+    options: SigninOptions = {},
+): Promise<NostrUser | null> {
+    const signedInUser = await userFromSigninMethod(method, options);
+    return completeSignin(signedInUser);
+}
 
+export async function completeSignin(
+    signedInUser: NostrUser | null,
+): Promise<NostrUser | null> {
     if (signedInUser) {
         let allowed = false;
         try {
             allowed = await isAllowedPubkey(signedInUser.pubkey);
         } catch (error) {
+            clearActiveSigner();
             toast.error("Unable to verify pubkey authorization");
             console.error(error);
             return null;
         }
 
         if (!allowed) {
+            clearActiveSigner();
             toast.error("Your pubkey is not authorized");
             return null;
         }
@@ -41,25 +58,30 @@ export async function signin(): Promise<NostrUser | null> {
     return signedInUser;
 }
 
-/**
- * Retrieves a user object using the raw NIP-07 browser extension API.
- * @async
- * @returns A Promise that resolves to a Nostr user if a NIP-07 extension is available, or null otherwise.
- */
-async function userFromNip07(): Promise<NostrUser | null> {
-    if (!hasNip07Extension()) {
-        toast.error("Install or enable a NIP-07 browser extension to sign in");
-        return null;
-    }
-
+async function userFromSigninMethod(
+    method: SigninMethod,
+    options: SigninOptions,
+): Promise<NostrUser | null> {
     try {
-        const user = userFromPubkey(await getExtensionPubkey());
-        if (!user) {
-            toast.error("The NIP-07 extension did not return a valid pubkey");
-            return null;
+        switch (method) {
+            case "extension":
+                return getExtensionUser();
+            case "nip46-bunker":
+                if (!options.bunkerUri) {
+                    toast.error("Paste a bunker:// remote signer connection string");
+                    return null;
+                }
+                return connectNostrConnectBunker(options.bunkerUri);
+            case "amber":
+                if (!isAmberSigninSupported()) {
+                    toast.error("Amber sign-in is only available on supported Android browsers");
+                    return null;
+                }
+                return getAmberUser();
+            default:
+                method satisfies never;
+                return null;
         }
-
-        return user;
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         toast.error(message);
@@ -72,8 +94,9 @@ async function userFromNip07(): Promise<NostrUser | null> {
  * Signs the user out.
  */
 export function signout() {
+    clearActiveSigner();
     setCurrentUser(null);
-    document.cookie = "keycastUserPubkey=";
+    document.cookie = "keycastUserPubkey=; max-age=0; SameSite=Lax; Secure; path=/";
     toast.success("Signed out");
     goto("/");
 }

--- a/web/src/lib/utils/http_auth.ts
+++ b/web/src/lib/utils/http_auth.ts
@@ -1,4 +1,5 @@
 export type HttpAuthMethod = "GET" | "POST" | "PUT" | "DELETE";
+export const NIP_98_HTTP_AUTH_KIND = 27235;
 const DEFAULT_LOCAL_API_ORIGIN = "http://localhost:3100";
 
 export function normalizeApiBaseUrl(

--- a/web/src/lib/utils/nostr.test.ts
+++ b/web/src/lib/utils/nostr.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, test } from "bun:test";
-import { npubForPubkey } from "$lib/nostr";
+import { afterEach, describe, expect, test } from "bun:test";
+import type { EventTemplate, NostrEvent } from "applesauce-core/helpers";
+import {
+    buildNip46SigningPermissions,
+    clearActiveSigner,
+    getActiveSignerSummary,
+    npubForPubkey,
+    normalizeBunkerUri,
+    setActiveSigner,
+    signNostrEvent,
+} from "$lib/nostr";
 import { truncatedNpubForPubkey, userFromPubkeyOrNpub } from "./nostr";
 
 const PUBKEY =
     "0000000000000000000000000000000000000000000000000000000000000001";
+const OTHER_PUBKEY =
+    "0000000000000000000000000000000000000000000000000000000000000002";
+
+afterEach(() => {
+    clearActiveSigner();
+});
 
 describe("Nostr helper utilities", () => {
     test("creates app users from hex pubkeys", () => {
@@ -32,4 +47,74 @@ describe("Nostr helper utilities", () => {
 
         expect(truncatedNpubForPubkey(PUBKEY, 12)).toBe(npub?.slice(0, 12));
     });
+
+    test("normalizes bunker URIs before connecting remote signers", () => {
+        expect(normalizeBunkerUri("  bunker://abc?relay=wss://relay.example  ")).toBe(
+            "bunker://abc?relay=wss://relay.example",
+        );
+
+        expect(() => normalizeBunkerUri("nostrconnect://abc")).toThrow(
+            "Paste a bunker:// remote signer connection string",
+        );
+    });
+
+    test("requests NIP-46 permission to sign NIP-98 HTTP auth events", () => {
+        expect(buildNip46SigningPermissions()).toEqual([
+            "get_public_key",
+            "sign_event:27235",
+        ]);
+    });
+
+    test("signs events with the active signer", async () => {
+        const template = authTemplate();
+        const signedEvent = signedAuthEvent(PUBKEY);
+
+        setActiveSigner({
+            kind: "extension",
+            signer: {
+                getPublicKey: async () => PUBKEY,
+                signEvent: async () => signedEvent,
+            },
+            pubkey: PUBKEY,
+        });
+
+        await expect(signNostrEvent(template, PUBKEY)).resolves.toEqual(signedEvent);
+        expect(getActiveSignerSummary()).toEqual({
+            kind: "extension",
+            pubkey: PUBKEY,
+        });
+    });
+
+    test("rejects events signed by a different pubkey", async () => {
+        setActiveSigner({
+            kind: "amber",
+            signer: {
+                getPublicKey: async () => PUBKEY,
+                signEvent: async () => signedAuthEvent(OTHER_PUBKEY),
+            },
+            pubkey: PUBKEY,
+        });
+
+        await expect(signNostrEvent(authTemplate(), PUBKEY)).rejects.toThrow(
+            "signed with a different pubkey",
+        );
+    });
 });
+
+function authTemplate(): EventTemplate {
+    return {
+        kind: 27235,
+        created_at: 1,
+        content: "",
+        tags: [["method", "GET"]],
+    };
+}
+
+function signedAuthEvent(pubkey: string): NostrEvent {
+    return {
+        ...authTemplate(),
+        id: `event-${pubkey}`,
+        pubkey,
+        sig: `sig-${pubkey}`,
+    };
+}


### PR DESCRIPTION
## Summary

- Adds a sign-in chooser for browser extension, NIP-46 remote signer, and Amber/NIP-55 flows.
- Uses Applesauce signers as the common auth primitive so extension, Nostr Connect, and Amber can all feed the existing NIP-98 API auth path.
- Adds NIP-46 bunker URL support plus generated `nostrconnect://` links requesting `get_public_key` and `sign_event:27235`.
- Keeps pubkey mismatch checks around signed NIP-98 events and clears active signer state on sign-out or allowlist failure.

## Validation

- `cd web && bun test`
- `cd web && bun run check`
- `cd web && bun run build`
- `git diff --check`
- Browser smoke test at `http://127.0.0.1:5173/`: opened the sign-in dialog, generated a Nostr Connect link, cancelled the pending session, and checked console warnings/errors.
