### PR TITLE
Fix security findings from the signing and deployment audits

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,39 +1,31 @@
-.git
-.gitignore
-.DS_Store
+# Allowlist form. Patterns without a leading ** match only the context root, so a
+# denylist silently misses paths such as legacy-v1/master.key, which UPGRADE.md
+# tells the operator to create inside the checkout. Everything is excluded here
+# and only the build inputs are added back.
+*
 
-# Rust build output
-target
+!Cargo.toml
+!Cargo.lock
+!api/
+!core/
+!signer/
+!database/migrations/
+!web/
+
+# Re-exclude anything sensitive or generated that lives under an allowed path.
 **/target
-
-# JavaScript dependencies and generated frontend output
-node_modules
 **/node_modules
 web/build
 web/.svelte-kit
-.svelte-kit
-build
-dist
-coverage
-
-# Local runtime state and secrets
-.env
-.env.*
-!.env.example
+web/test-results
+**/.env
+**/.env.*
 !**/.env.example
-master.key
-*.db
-*.db-shm
-*.db-wal
-database/*.db
-database/*.db-shm
-database/*.db-wal
-
-# Editor and OS scratch files
-*.swp
-*.swo
-Thumbs.db
-
-# Interrupted credential creation and encrypted recovery archives
-.keycast-root.*
-*.kcb
+**/master.key
+**/*.db
+**/*.db-shm
+**/*.db-wal
+**/*.kcb
+**/.keycast-root.*
+**/.DS_Store
+**/__pycache__

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 # Remember to set your DNS records!
 DOMAIN=your-domain.com
 
+# Where persistent state lives. Defaults to this checkout; point it at a path
+# such as /srv/keycast to keep the database and root credential away from git.
+# KEYCAST_STATE_DIR=/srv/keycast
+
 # Comma-separated 64-character hex pubkeys trusted to operate this instance.
 # The signer fails closed when this is empty.
 ALLOWED_PUBKEYS=hexpubkey1,hexpubkey2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+
+# Actions and base images are pinned by commit SHA and digest, which is only safe
+# if something keeps them current. That is this file's job.
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "docker"
+
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "cargo"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: bun
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "web"
+
+  - package-ecosystem: bun
+    directory: "/web"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "web"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # The SHA below is the tip of this action's `1.96.0` branch, which is where
+      # it reads the version from; there is no `toolchain` input to pass.
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@ebb3d1676050bfd0971c36c1e215b5751473994d # 1.96.0
         with:
-          toolchain: "1.96.0"
           components: rustfmt
 
       - name: Cache Rust build artifacts
@@ -122,10 +123,9 @@ jobs:
         with:
           persist-credentials: false
 
+      # Pinned to the tip of the action's `1.96.0` branch; see the Rust job above.
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@ebb3d1676050bfd0971c36c1e215b5751473994d # 1.96.0
-        with:
-          toolchain: "1.96.0"
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked --version 0.22.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,41 +103,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Render Compose files
-        env:
-          DOMAIN: keycast.example
-          ALLOWED_PUBKEYS: "0000000000000000000000000000000000000000000000000000000000000001"
-          KEYCAST_OPERATOR_PUBKEYS: "0000000000000000000000000000000000000000000000000000000000000001"
-          KEYCAST_API_DIGEST: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
-          KEYCAST_SIGNER_DIGEST: "sha256:2222222222222222222222222222222222222222222222222222222222222222"
-          KEYCAST_WEB_DIGEST: "sha256:3333333333333333333333333333333333333333333333333333333333333333"
-        run: |
-          set -euo pipefail
-          docker compose -f docker-compose.yml config --quiet
-          docker compose -f docker-compose.prod.yml config --quiet
-          docker compose -f caddy-docker-compose-example.yml config --quiet
+      - name: Check Compose hardening
+        run: bash scripts/check-compose-hardening.sh
 
-      - name: Assert the hardening defaults are present
-        env:
-          DOMAIN: keycast.example
-          ALLOWED_PUBKEYS: "0000000000000000000000000000000000000000000000000000000000000001"
-          KEYCAST_OPERATOR_PUBKEYS: "0000000000000000000000000000000000000000000000000000000000000001"
+      - name: Check shell scripts
         run: |
           set -euo pipefail
-          rendered="$(docker compose -f docker-compose.yml config)"
-          # Swap must be disabled wherever plaintext key material can live.
-          for service_limit in memswap_limit read_only; do
-            test "$(printf '%s' "$rendered" | grep -c "$service_limit")" -ge 3 \
-              || { echo "missing $service_limit on every service"; exit 1; }
-          done
-          printf '%s' "$rendered" | grep -q 'noexec,nosuid,nodev' || { echo "tmpfs is not hardened"; exit 1; }
-          # The signer must not share the ingress network with the public transport.
-          printf '%s' "$rendered" | grep -q 'keycast-signer-egress' || { echo "signer egress network missing"; exit 1; }
-          # No proxy may be handed the Docker socket.
-          ! grep -rq 'docker\.sock' docker-compose.yml docker-compose.prod.yml caddy-docker-compose-example.yml \
-            || { echo "a compose file mounts the Docker socket"; exit 1; }
-          # Secrets must never be reachable from the build context.
-          grep -q '^\*$' .dockerignore || { echo ".dockerignore is not allowlist form"; exit 1; }
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          shellcheck -S warning scripts/*.sh
 
   security:
     name: Dependency security

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+# Every `uses:` is pinned to a commit SHA. A tag is mutable, and this repository's
+# other workflow holds `packages: write`, so a hijacked tag could publish an image
+# that operators then pin by digest. Dependabot keeps these current.
+
 on:
   pull_request:
   push:
@@ -20,19 +24,23 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@ebb3d1676050bfd0971c36c1e215b5751473994d # 1.96.0
         with:
+          toolchain: "1.96.0"
           components: rustfmt
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Generate test master key
         run: |
           set -euo pipefail
+          umask 077
           openssl rand 32 | base64 > master.key
           chmod 600 master.key
 
@@ -41,6 +49,9 @@ jobs:
 
       - name: Check Rust workspace
         run: cargo check --workspace --locked
+
+      - name: Check the core crate builds and tests standalone
+        run: cargo test -p keycast_core --locked --no-run
 
       - name: Build Rust workspace
         run: cargo build --workspace --locked
@@ -61,10 +72,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.9
 
@@ -80,25 +93,75 @@ jobs:
       - name: Build web package
         run: bun run build
 
+  deployment:
+    name: Deployment configuration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Render Compose files
+        env:
+          DOMAIN: keycast.example
+          ALLOWED_PUBKEYS: "0000000000000000000000000000000000000000000000000000000000000001"
+          KEYCAST_OPERATOR_PUBKEYS: "0000000000000000000000000000000000000000000000000000000000000001"
+          KEYCAST_API_DIGEST: "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+          KEYCAST_SIGNER_DIGEST: "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+          KEYCAST_WEB_DIGEST: "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+        run: |
+          set -euo pipefail
+          docker compose -f docker-compose.yml config --quiet
+          docker compose -f docker-compose.prod.yml config --quiet
+          docker compose -f caddy-docker-compose-example.yml config --quiet
+
+      - name: Assert the hardening defaults are present
+        env:
+          DOMAIN: keycast.example
+          ALLOWED_PUBKEYS: "0000000000000000000000000000000000000000000000000000000000000001"
+          KEYCAST_OPERATOR_PUBKEYS: "0000000000000000000000000000000000000000000000000000000000000001"
+        run: |
+          set -euo pipefail
+          rendered="$(docker compose -f docker-compose.yml config)"
+          # Swap must be disabled wherever plaintext key material can live.
+          for service_limit in memswap_limit read_only; do
+            test "$(printf '%s' "$rendered" | grep -c "$service_limit")" -ge 3 \
+              || { echo "missing $service_limit on every service"; exit 1; }
+          done
+          printf '%s' "$rendered" | grep -q 'noexec,nosuid,nodev' || { echo "tmpfs is not hardened"; exit 1; }
+          # The signer must not share the ingress network with the public transport.
+          printf '%s' "$rendered" | grep -q 'keycast-signer-egress' || { echo "signer egress network missing"; exit 1; }
+          # No proxy may be handed the Docker socket.
+          ! grep -rq 'docker\.sock' docker-compose.yml docker-compose.prod.yml caddy-docker-compose-example.yml \
+            || { echo "a compose file mounts the Docker socket"; exit 1; }
+          # Secrets must never be reachable from the build context.
+          grep -q '^\*$' .dockerignore || { echo ".dockerignore is not allowlist form"; exit 1; }
+
   security:
     name: Dependency security
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@ebb3d1676050bfd0971c36c1e215b5751473994d # 1.96.0
+        with:
+          toolchain: "1.96.0"
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: cargo install cargo-audit --locked --version 0.22.0
 
       - name: Audit Rust dependencies
         run: cargo audit
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.9
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,10 +3,11 @@ name: Docker Images
 # Only a smoke-tested artefact reaches an operator-facing tag.
 #
 # The build is pushed once to an immutable `sha-` tag, that exact digest is
-# pulled back and smoke-tested, and only then is the same digest promoted to
-# `v2` and `latest` with `imagetools create`, which re-points tags without
-# rebuilding. A rebuild for publication could differ from the tested image:
-# `apt-get install` is time-dependent whenever the layer cache misses.
+# pulled back and smoke-tested, then attested, and only then promoted to `v2` and
+# `latest` with `imagetools create`, which re-points tags without rebuilding.
+# Promotion runs last so those tags can never resolve to a digest whose smoke
+# test or attestation failed. A rebuild for publication could differ from the
+# tested image: `apt-get install` is time-dependent when the layer cache misses.
 #
 # Operators pin a digest, and a digest only pins what you already trust, so
 # `scripts/upgrade_preflight.sh` verifies the attestation minted below.
@@ -129,23 +130,6 @@ jobs:
           docker tag "${WEB_IMAGE}@${{ steps.web.outputs.digest }}" keycast-hardening-web:local
           scripts/container-smoke.sh
 
-      # Re-point the tags at the tested digests. No rebuild, so the artefact an
-      # operator pulls from v2 is byte-identical to the one smoke-tested above.
-      - name: Promote the tested digests
-        if: github.ref == 'refs/heads/master'
-        run: |
-          set -euo pipefail
-          promote() {
-            local image="$1" digest="$2"
-            docker buildx imagetools create \
-              --tag "${image}:v2" \
-              --tag "${image}:latest" \
-              "${image}@${digest}"
-          }
-          promote "$API_IMAGE" "${{ steps.api.outputs.digest }}"
-          promote "$SIGNER_IMAGE" "${{ steps.signer.outputs.digest }}"
-          promote "$WEB_IMAGE" "${{ steps.web.outputs.digest }}"
-
       - name: Attest API build provenance
         if: github.ref == 'refs/heads/master'
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
@@ -169,6 +153,25 @@ jobs:
           subject-name: ${{ env.WEB_IMAGE }}
           subject-digest: ${{ steps.web.outputs.digest }}
           push-to-registry: true
+
+      # Last, so v2 and latest can never resolve to a digest whose attestation
+      # failed and which scripts/upgrade_preflight.sh would therefore reject.
+      # No rebuild: the artefact an operator pulls is byte-identical to the one
+      # smoke-tested above.
+      - name: Promote the tested and attested digests
+        if: github.ref == 'refs/heads/master'
+        run: |
+          set -euo pipefail
+          promote() {
+            local image="$1" digest="$2"
+            docker buildx imagetools create \
+              --tag "${image}:v2" \
+              --tag "${image}:latest" \
+              "${image}@${digest}"
+          }
+          promote "$API_IMAGE" "${{ steps.api.outputs.digest }}"
+          promote "$SIGNER_IMAGE" "${{ steps.signer.outputs.digest }}"
+          promote "$WEB_IMAGE" "${{ steps.web.outputs.digest }}"
 
       # The digests an operator copies into .env, with the verify command.
       - name: Report digests for pinning

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,15 @@
 name: Docker Images
 
-# Images are built with provenance and an SBOM, then attested. Operators pin a
-# digest, and a digest only pins what you already trust, so `upgrade_preflight.sh`
-# verifies that digest was produced by this workflow via `gh attestation verify`.
+# Only a smoke-tested artefact reaches an operator-facing tag.
+#
+# The build is pushed once to an immutable `sha-` tag, that exact digest is
+# pulled back and smoke-tested, and only then is the same digest promoted to
+# `v2` and `latest` with `imagetools create`, which re-points tags without
+# rebuilding. A rebuild for publication could differ from the tested image:
+# `apt-get install` is time-dependent whenever the layer cache misses.
+#
+# Operators pin a digest, and a digest only pins what you already trust, so
+# `scripts/upgrade_preflight.sh` verifies the attestation minted below.
 
 on:
   push:
@@ -45,22 +52,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      # Build locally and smoke test before anything is published, so a broken
-      # or unsafe image never reaches a tag an operator might read a digest from.
-      - name: Build all runtime targets
+      # Gate the code before anything is pushed, including on a branch dispatch
+      # where no publication happens at all.
+      - name: Build all runtime targets locally
         run: |
           set -euo pipefail
-          docker buildx build --load --target api-runtime --tag keycast-api:ci .
-          docker buildx build --load --target signer-runtime --tag keycast-signer:ci .
-          docker buildx build --load --target web-runtime --tag keycast-web:ci .
+          docker buildx build --load --target api-runtime --tag keycast-hardening-api:local .
+          docker buildx build --load --target signer-runtime --tag keycast-hardening-signer:local .
+          docker buildx build --load --target web-runtime --tag keycast-hardening-web:local .
 
-      - name: Smoke test hardened process split
-        run: |
-          set -euo pipefail
-          docker tag keycast-api:ci keycast-hardening-api:local
-          docker tag keycast-signer:ci keycast-hardening-signer:local
-          docker tag keycast-web:ci keycast-hardening-web:local
-          scripts/container-smoke.sh
+      - name: Smoke test the local build
+        run: scripts/container-smoke.sh
 
       - name: Log in to GitHub Container Registry
         if: github.ref == 'refs/heads/master'
@@ -70,12 +72,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compute image tags
+      - name: Compute the immutable tag
         if: github.ref == 'refs/heads/master'
         id: tags
         run: echo "short_sha=${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
 
-      - name: Publish API image
+      # Push to the immutable sha- tag only. v2 and latest are not moved until
+      # the pushed digest itself has passed the smoke test below.
+      - name: Push API image to its immutable tag
         if: github.ref == 'refs/heads/master'
         id: api
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -85,12 +89,9 @@ jobs:
           push: true
           provenance: mode=max
           sbom: true
-          tags: |
-            ${{ env.API_IMAGE }}:v2
-            ${{ env.API_IMAGE }}:latest
-            ${{ env.API_IMAGE }}:sha-${{ steps.tags.outputs.short_sha }}
+          tags: ${{ env.API_IMAGE }}:sha-${{ steps.tags.outputs.short_sha }}
 
-      - name: Publish signer image
+      - name: Push signer image to its immutable tag
         if: github.ref == 'refs/heads/master'
         id: signer
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -100,12 +101,9 @@ jobs:
           push: true
           provenance: mode=max
           sbom: true
-          tags: |
-            ${{ env.SIGNER_IMAGE }}:v2
-            ${{ env.SIGNER_IMAGE }}:latest
-            ${{ env.SIGNER_IMAGE }}:sha-${{ steps.tags.outputs.short_sha }}
+          tags: ${{ env.SIGNER_IMAGE }}:sha-${{ steps.tags.outputs.short_sha }}
 
-      - name: Publish web image
+      - name: Push web image to its immutable tag
         if: github.ref == 'refs/heads/master'
         id: web
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -115,10 +113,38 @@ jobs:
           push: true
           provenance: mode=max
           sbom: true
-          tags: |
-            ${{ env.WEB_IMAGE }}:v2
-            ${{ env.WEB_IMAGE }}:latest
-            ${{ env.WEB_IMAGE }}:sha-${{ steps.tags.outputs.short_sha }}
+          tags: ${{ env.WEB_IMAGE }}:sha-${{ steps.tags.outputs.short_sha }}
+
+      # Smoke the exact published artefacts, not a second local build.
+      - name: Smoke test the published digests
+        if: github.ref == 'refs/heads/master'
+        run: |
+          set -euo pipefail
+          docker image rm -f keycast-hardening-api:local keycast-hardening-signer:local keycast-hardening-web:local
+          docker pull "${API_IMAGE}@${{ steps.api.outputs.digest }}"
+          docker pull "${SIGNER_IMAGE}@${{ steps.signer.outputs.digest }}"
+          docker pull "${WEB_IMAGE}@${{ steps.web.outputs.digest }}"
+          docker tag "${API_IMAGE}@${{ steps.api.outputs.digest }}" keycast-hardening-api:local
+          docker tag "${SIGNER_IMAGE}@${{ steps.signer.outputs.digest }}" keycast-hardening-signer:local
+          docker tag "${WEB_IMAGE}@${{ steps.web.outputs.digest }}" keycast-hardening-web:local
+          scripts/container-smoke.sh
+
+      # Re-point the tags at the tested digests. No rebuild, so the artefact an
+      # operator pulls from v2 is byte-identical to the one smoke-tested above.
+      - name: Promote the tested digests
+        if: github.ref == 'refs/heads/master'
+        run: |
+          set -euo pipefail
+          promote() {
+            local image="$1" digest="$2"
+            docker buildx imagetools create \
+              --tag "${image}:v2" \
+              --tag "${image}:latest" \
+              "${image}@${digest}"
+          }
+          promote "$API_IMAGE" "${{ steps.api.outputs.digest }}"
+          promote "$SIGNER_IMAGE" "${{ steps.signer.outputs.digest }}"
+          promote "$WEB_IMAGE" "${{ steps.web.outputs.digest }}"
 
       - name: Attest API build provenance
         if: github.ref == 'refs/heads/master'
@@ -144,12 +170,12 @@ jobs:
           subject-digest: ${{ steps.web.outputs.digest }}
           push-to-registry: true
 
-      # The digests an operator must copy into .env, alongside the verify command.
+      # The digests an operator copies into .env, with the verify command.
       - name: Report digests for pinning
         if: github.ref == 'refs/heads/master'
         run: |
           {
-            echo "## Reviewed digests for .env"
+            echo "## Smoke-tested digests for .env"
             echo
             echo '```sh'
             echo "KEYCAST_API_DIGEST=${{ steps.api.outputs.digest }}"
@@ -161,9 +187,9 @@ jobs:
             echo
             echo '```sh'
             for pair in \
-              "${{ env.API_IMAGE }}@${{ steps.api.outputs.digest }}" \
-              "${{ env.SIGNER_IMAGE }}@${{ steps.signer.outputs.digest }}" \
-              "${{ env.WEB_IMAGE }}@${{ steps.web.outputs.digest }}"; do
+              "${API_IMAGE}@${{ steps.api.outputs.digest }}" \
+              "${SIGNER_IMAGE}@${{ steps.signer.outputs.digest }}" \
+              "${WEB_IMAGE}@${{ steps.web.outputs.digest }}"; do
               echo "gh attestation verify oci://$pair --repo ${{ github.repository }}"
             done
             echo '```'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,9 @@
 name: Docker Images
 
+# Images are built with provenance and an SBOM, then attested. Operators pin a
+# digest, and a digest only pins what you already trust, so `upgrade_preflight.sh`
+# verifies that digest was produced by this workflow via `gh attestation verify`.
+
 on:
   push:
     branches:
@@ -8,7 +12,11 @@ on:
 
 permissions:
   contents: read
-  packages: write
+
+# Never let two publishes race for the same mutable tags.
+concurrency:
+  group: docker-publish
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -21,20 +29,24 @@ jobs:
     name: Build, smoke, and publish v2 images
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+      # Required to mint the provenance attestations below.
+      id-token: write
+      attestations: write
+
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
+      # Build locally and smoke test before anything is published, so a broken
+      # or unsafe image never reaches a tag an operator might read a digest from.
       - name: Build all runtime targets
         run: |
           set -euo pipefail
@@ -50,18 +62,109 @@ jobs:
           docker tag keycast-web:ci keycast-hardening-web:local
           scripts/container-smoke.sh
 
-      - name: Tag and publish images
+      - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/master'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        if: github.ref == 'refs/heads/master'
+        id: tags
+        run: echo "short_sha=${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish API image
+        if: github.ref == 'refs/heads/master'
+        id: api
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: api-runtime
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: |
+            ${{ env.API_IMAGE }}:v2
+            ${{ env.API_IMAGE }}:latest
+            ${{ env.API_IMAGE }}:sha-${{ steps.tags.outputs.short_sha }}
+
+      - name: Publish signer image
+        if: github.ref == 'refs/heads/master'
+        id: signer
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: signer-runtime
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: |
+            ${{ env.SIGNER_IMAGE }}:v2
+            ${{ env.SIGNER_IMAGE }}:latest
+            ${{ env.SIGNER_IMAGE }}:sha-${{ steps.tags.outputs.short_sha }}
+
+      - name: Publish web image
+        if: github.ref == 'refs/heads/master'
+        id: web
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: web-runtime
+          push: true
+          provenance: mode=max
+          sbom: true
+          tags: |
+            ${{ env.WEB_IMAGE }}:v2
+            ${{ env.WEB_IMAGE }}:latest
+            ${{ env.WEB_IMAGE }}:sha-${{ steps.tags.outputs.short_sha }}
+
+      - name: Attest API build provenance
+        if: github.ref == 'refs/heads/master'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.API_IMAGE }}
+          subject-digest: ${{ steps.api.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest signer build provenance
+        if: github.ref == 'refs/heads/master'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.SIGNER_IMAGE }}
+          subject-digest: ${{ steps.signer.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest web build provenance
+        if: github.ref == 'refs/heads/master'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.WEB_IMAGE }}
+          subject-digest: ${{ steps.web.outputs.digest }}
+          push-to-registry: true
+
+      # The digests an operator must copy into .env, alongside the verify command.
+      - name: Report digests for pinning
+        if: github.ref == 'refs/heads/master'
         run: |
-          set -euo pipefail
-          short_sha="${GITHUB_SHA:0:12}"
-          for component in api signer web; do
-            case "$component" in
-              api) destination="$API_IMAGE" ;;
-              signer) destination="$SIGNER_IMAGE" ;;
-              web) destination="$WEB_IMAGE" ;;
-            esac
-            for tag in v2 latest "sha-$short_sha"; do
-              docker tag "keycast-$component:ci" "$destination:$tag"
-              docker push "$destination:$tag"
+          {
+            echo "## Reviewed digests for .env"
+            echo
+            echo '```sh'
+            echo "KEYCAST_API_DIGEST=${{ steps.api.outputs.digest }}"
+            echo "KEYCAST_SIGNER_DIGEST=${{ steps.signer.outputs.digest }}"
+            echo "KEYCAST_WEB_DIGEST=${{ steps.web.outputs.digest }}"
+            echo '```'
+            echo
+            echo "Verify each before deploying:"
+            echo
+            echo '```sh'
+            for pair in \
+              "${{ env.API_IMAGE }}@${{ steps.api.outputs.digest }}" \
+              "${{ env.SIGNER_IMAGE }}@${{ steps.signer.outputs.digest }}" \
+              "${{ env.WEB_IMAGE }}@${{ steps.web.outputs.digest }}"; do
+              echo "gh attestation verify oci://$pair --repo ${{ github.repository }}"
             done
-          done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -59,6 +59,57 @@ management-kind denial, stale grant claiming, unknown-client inbox protection, f
 and a real CLI backup/rotation/restore drill. The container smoke exercises signed HTTP management
 through the API and socket, browser import, and encrypted invitation creation.
 
+## Second review pass, September 9, 2026
+
+A further review covered the signer authorization router, NIP-46 pipeline, envelope and backup
+cryptography, the SvelteKit frontend, and the container/CI/operations layer. No critical or
+high-severity issue was found in application code. The findings below were fixed in this pass.
+
+| Priority | Finding | Fix |
+|---|---|---|
+| High | The shipped Caddy example mounted `/var/run/docker.sock`. Read-only applies to the socket file, not the Docker API sent over it, so code execution in the only Internet-facing process was root-equivalent on the host | Replaced with a static `Caddyfile.example` and a hardened proxy service: no socket, dropped capabilities, `read_only`, limits, and body limits for `/api/*`. The dead `caddy=` labels were removed |
+| Medium | Relay admission spent the shared per-second budget before verifying signatures or sessions. A remote-signer pubkey is public, so ~128 forged events per second on any shared relay could starve signing for every grant | Split admission into two lanes. Clients with a live session on the target grant draw from the established lane; everything else, including `connect`, draws from a smaller newcomer lane that cannot exhaust it. The live-session index refreshes with the grant configuration |
+| Medium | Management write replies were encrypted to a fresh per-reply key, so NIP-44 had nothing to authenticate. Anyone on path, including the untrusted API, could forge an outcome such as a `bunker://` URI pointing at their own signer | The signer derives a stable reply identity from the root credential and publishes its public half through `/config`. The browser pins it, decrypts only with the pinned key, and fails closed on a change. The Status page shows the fingerprint for comparison against `keycast_signer status` |
+| Medium | The NIP-46 sign-in popup opened a signer-supplied `auth_url` with an `opener` handle and no scheme check, so a malicious handshake relay could navigate the operator's tab mid sign-in | The URL must be `https:`, the popup is opened with `noopener,noreferrer`, and `Cross-Origin-Opener-Policy: same-origin` is set |
+| Medium | One flat bridge network gave the API and web containers unused Internet egress and placed the signer beside the proxy | `keycast` is created `--internal`; the signer has its own egress-only network; the proxy keeps a public network for ACME and ports |
+| Medium | `mem_limit` without `memswap_limit` allowed decrypted key material to be paged to host swap, which outlives the container | `memswap_limit` equals `mem_limit`, disabling swap for the cgroup. `/tmp` is also `noexec,nosuid,nodev` |
+| Medium | `.dockerignore` patterns were root-anchored, so the `legacy-v1/master.key` that `UPGRADE.md` instructs the operator to create would enter the build context, as would `web/.env` | Rewritten in allowlist form and verified by building the real context with planted decoy secrets. `UPGRADE.md` now archives legacy files outside the checkout |
+| Medium | Actions were pinned by mutable tag, images shipped without provenance, the publish step could run from any ref, and the documented "reviewed digest" had no procedure | Every action is pinned to a commit SHA with Dependabot to maintain them; images are built with provenance and an SBOM and attested; publishing is guarded to `master` and serialized; `upgrade_preflight.sh` runs `gh attestation verify` and fails closed |
+| Medium | `DELETE /teams/{id}` could never succeed once a team had any grant, including a revoked one: `grants` references `policies` with `ON DELETE RESTRICT` while `policies` cascades from `teams` | The handler deletes the team's grants inside the same immediate transaction. Reproduced against the real migrations before and after |
+| Low | `sign_event` forwarded a client-supplied event `id`. The nostr crate signs `unsigned.id` before verifying it, so the signer briefly produced a Schnorr signature over an attacker-chosen 32-byte value even though the mismatch was rejected | The `id` is always stripped and recomputed |
+| Low | Imported private keys left several unzeroized copies, and `AddKeyRequest` derived `Debug` over the plaintext | A `Secret` newtype erases its buffer on drop and redacts `Debug`; it is used on the control-socket body, the import request and the lifecycle request, and the lifecycle request is no longer cloned. The approval description now parses only the key name |
+| Low | An approval echoing a request body could carry private material to an external signer | Both the signer and the browser refuse to sign or accept an approval whose content contains `secret_key` or `nsec1`, including an operator pasting a key into the name field |
+| Low | `backup` accepted the root credential as the backup key, and the manifest carries the root | Rejected: the backup key must differ from the root |
+| Low | CSP allowed blanket `https:` in `connect-src` and `http:` in `img-src` | Narrowed to `'self'` and `wss:`; COOP and CORP added |
+| Low | Every signed-in page load fetched a contact list that nothing read, announcing the operator's pubkey and IP to five public relays, and the loader followed relay hints from fetched events | The follows feature was removed and `followRelayHints` is off |
+| Low | The `[pubkey]` route parameter was interpolated unvalidated into signed request paths | Rejected unless it is 32-byte lowercase hex |
+| Low | `upgrade_preflight.sh` opened the live database read-write as root after the ownership repair, which could leave root-owned WAL sidecars the container user cannot open | The check runs first, read-only, and warns about mis-owned sidecars |
+| Low | Systemd templates lacked kernel, namespace and syscall restrictions, and the web image let the runtime user own `/app` | Templates hardened with an empty capability bounding set and a `@system-service` filter; `/app` is root-owned |
+| Info | `decode_hex` accepted a leading sign, a non-regular credential file blocked startup inside a read, and the Dockerfile frontend was a mutable tag | Strict hex digits, regular-file check, digest-pinned frontend |
+| Info | `CREDENTIALS_DIRECTORY` silently won over an explicit `KEYCAST_ROOT_KEY_FILE`, and persistent state had to live inside the checkout | Setting both credential sources is rejected outright; `KEYCAST_STATE_DIR` relocates the database and root credential, defaulting to the checkout |
+
+Two findings from an external review were investigated and **not** reproduced as issues. Discovered
+relays do not bypass the SSRF vetting: the runtime places every discovered relay in a restricted set
+and the custom transport routes those connections through `public_relay::connect`, which re-resolves
+and re-validates every DNS answer on each connect and refuses proxies. Unauthenticated read
+flooding remains bounded by the existing admission and socket limits.
+
+Known residual, unchanged:
+
+- Browser key import still moves the private key through the API process and through HTTP and JSON
+  buffers that cannot be zeroized from application code. The `Secret` wrapper narrows the window;
+  the trusted CLI remains the stronger path and the UI says so.
+- The API and the signer still share UID 10001. The socket permission fallback for filesystems that
+  reject `chmod` on a Unix socket deliberately depends on that, and the API has no writable mount to
+  own anything with, so the split was not worth breaking that path.
+- The API's per-peer upload budget still sees only the proxy address. `Caddyfile.example` sets body
+  limits; a per-IP rate limit needs a Caddy plugin or a host firewall, and is tracked in `TODO.md`.
+- Management reads (kind 27237) carry no nonce and stay replayable inside their 60-second window.
+  Reads pass through the API in plaintext regardless and expose no secrets.
+- The `ca-certificates` layer stays in the Rust runtime image. The signer uses webpki roots, so it
+  is unnecessary, but a CA bundle is not meaningful attack surface and removing it risks TLS
+  breakage that no local test would catch.
+
 ## Remaining deployment work and limits
 
 1. Obtain independent security review of the new management protocol, authorization transactions,

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -119,6 +119,18 @@ Addressed from the pull request review:
 - `UPGRADE.md` restarts the Keycast stack after the network is recreated; the previous ordering left
   the signer, API and web containers stopped.
 
+Second follow-up round:
+
+- The reply-key pin is mirrored into memory whenever a persisted pin is read, not only when one is
+  established. A returning browser starts each page load with an empty session pin, so storage that
+  failed partway through a session would otherwise drop the anchor and accept a substituted identity
+  as another first use.
+- The state-relocation procedure moves the database files rather than the `database/` directory.
+  `database/migrations` is tracked source that the image build and the Rust tests read, so moving it
+  would have broken both; the signer reads migrations from inside the image.
+- That procedure also restarts the stack and verifies it, instead of ending on a validation step
+  that leaves every container stopped.
+
 Two findings from an external review were investigated and **not** reproduced as issues. Discovered
 relays do not bypass the SSRF vetting: the runtime places every discovered relay in a restricted set
 and the custom transport routes those connections through `public_relay::connect`, which re-resolves

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -131,6 +131,22 @@ Second follow-up round:
 - That procedure also restarts the stack and verifies it, instead of ending on a validation step
   that leaves every container stopped.
 
+Third follow-up round:
+
+- Tag promotion runs after every provenance attestation. Promoting first meant a failed attestation
+  could leave `v2` and `latest` resolving to a digest that `upgrade_preflight.sh` then rejects.
+- The Compose hardening checks run against `docker-compose.prod.yml` as well as the source file.
+  Production is what operators deploy, and only the source file was being asserted.
+- The state-relocation move runs inside one privileged shell. `database/` is mode `0700` owned by
+  UID 10001, so an ordinary operator's shell cannot list it to expand the wildcard: bash passes the
+  literal pattern and zsh refuses, while the credential move and `.env` edit that followed would
+  still succeed and leave the signer pointed at an empty directory. Validated as a non-root operator
+  against the shipped mode: the block now refuses and leaves nothing half-migrated.
+- Permission repair requires the database directory to exist, so a missing directory reports a
+  failure instead of aborting under `set -e` before the summary prints.
+- `init.sh` invokes `generate_key.sh` by absolute path. The existing `cd` made this work, but the
+  absolute path cannot be broken by a later edit that moves that `cd`.
+
 Two findings from an external review were investigated and **not** reproduced as issues. Discovered
 relays do not bypass the SSRF vetting: the runtime places every discovered relay in a restricted set
 and the custom transport routes those connections through `public_relay::connect`, which re-resolves

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -88,6 +88,37 @@ high-severity issue was found in application code. The findings below were fixed
 | Info | `decode_hex` accepted a leading sign, a non-regular credential file blocked startup inside a read, and the Dockerfile frontend was a mutable tag | Strict hex digits, regular-file check, digest-pinned frontend |
 | Info | `CREDENTIALS_DIRECTORY` silently won over an explicit `KEYCAST_ROOT_KEY_FILE`, and persistent state had to live inside the checkout | Setting both credential sources is rejected outright; `KEYCAST_STATE_DIR` relocates the database and root credential, defaulting to the checkout |
 
+## Review follow-up, September 9, 2026
+
+Addressed from the pull request review:
+
+- Publication now pushes to an immutable `sha-` tag, smoke-tests that exact digest, and only then
+  promotes it to `v2`/`latest` with `imagetools create`. A rebuild for publication could differ from
+  the tested image, because `apt-get install` is time-dependent when the layer cache misses.
+- The Compose hardening assertions moved into `scripts/check-compose-hardening.sh`, which inspects
+  rendered mounts instead of file text. The previous text search matched the comment documenting the
+  socket removal, so the job failed on the very configuration it was meant to accept.
+- The reply-key pin is retained in memory when browser storage is unavailable, disabled, or
+  throwing. Without that, every request became another first use and an API compromised mid-session
+  could substitute its identity without tripping the change warning.
+- The reply identity and its re-trust control now load from the unauthenticated `/config` rather
+  than the operator-only `/status`, so a team administrator who is not an instance operator can
+  still recover after a root-credential rotation.
+- `connect-src` accepts the explicitly configured API origin again, so a split-origin HTTPS
+  deployment is not blocked by the removal of the blanket `https:` source.
+- `KEYCAST_STATE_DIR` is honoured by `scripts/init.sh`, `scripts/generate_key.sh` and
+  `scripts/upgrade_preflight.sh`, so setup, validation and permission repair act on the same paths
+  Compose mounts rather than a stale copy in the checkout.
+- Preflight uses the plain database path with `sqlite3 -readonly`, tries GNU `stat -c` before the
+  BSD form, and reports the `gh attestation verify` diagnostic so an authentication or network
+  failure is not recorded as missing provenance.
+- The starvation regression waits on a new `configuration_reloads` counter instead of sleeping, and
+  the admission unit test asserts the constants that actually bind.
+- A test compares the Rust and TypeScript secret-marker lists, since the browser refuses first and a
+  marker present only in the signer would let content reach an external key store.
+- `UPGRADE.md` restarts the Keycast stack after the network is recreated; the previous ordering left
+  the signer, API and web containers stopped.
+
 Two findings from an external review were investigated and **not** reproduced as issues. Discovered
 relays do not bypass the SSRF vetting: the runtime places every discovered relay in a restricted set
 and the custom transport routes those connections through `public_relay::connect`, which re-resolves

--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -1,0 +1,56 @@
+# Static reverse proxy configuration for a Keycast instance.
+#
+# A static file is used deliberately. Label-driven proxies need the Docker socket,
+# which is root-equivalent on the host: a compromise of the only process parsing
+# untrusted Internet traffic would then expose master.key, the database, and the
+# signer itself. Keycast has exactly two upstreams, so discovery buys nothing.
+#
+# Copy to ./Caddyfile and set DOMAIN in .env before starting the proxy.
+
+{
+	# No admin API. It would otherwise listen on localhost:2019 inside the
+	# container and can reconfigure the proxy.
+	admin off
+	# Uncomment for the staging CA while testing certificate issuance.
+	# acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+}
+
+{$DOMAIN} {
+	encode zstd gzip
+
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options nosniff
+		Referrer-Policy no-referrer
+		Cross-Origin-Opener-Policy same-origin
+		-Server
+	}
+
+	# The API's own per-peer upload budget sees only this proxy's address, so the
+	# ceilings that matter for public clients are set here.
+	handle /api/* {
+		request_body {
+			# Matches MAX_HTTP_BODY in core/src/v2/management.rs.
+			max_size 1MB
+		}
+		reverse_proxy keycast-api:3000 {
+			header_up X-Forwarded-Proto https
+		}
+	}
+
+	handle {
+		request_body {
+			max_size 1MB
+		}
+		reverse_proxy keycast-web:5173 {
+			header_up X-Forwarded-Proto https
+		}
+	}
+
+	log {
+		output stdout
+		format console
+		# Management URLs carry public keys; keep proxy logs off by default if
+		# that metadata matters to you.
+	}
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 base64 = "0.23.1"
 chrono = { version = "0.4.45", features = ["serde"] }
-nostr = { version = "=0.45.4", features = ["nip04", "nip44", "nip46"] }
+nostr = { version = "=0.45.4", features = ["std", "os-rng", "nip04", "nip44", "nip46"] }
 nostr-sdk = "=0.45.2"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.20.0@sha256:26147acbda4f14c5add9946e2fd2ed543fc402884fd75146bd342a7f6271dc1d
 
 FROM rust:1.96.0-slim-bookworm@sha256:4732ca96fd086cb9be682050c3f0176288eebaac2b80aa2bcefccfaf198e1950 AS rust-builder
 WORKDIR /app
@@ -61,7 +61,7 @@ FROM node:24-bookworm-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c
 LABEL org.opencontainers.image.source="https://github.com/marmot-protocol/keycast"
 RUN groupadd --system --gid 10001 keycast \
     && useradd --system --uid 10001 --gid keycast --home-dir /nonexistent --shell /usr/sbin/nologin keycast \
-    && install -d -o keycast -g keycast -m 0755 /app
+    && install -d -o root -g root -m 0755 /app
 WORKDIR /app
 COPY --chown=root:root --from=web-builder /app/build ./web
 COPY --chown=root:root --from=web-builder /app/package.json ./package.json

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Requirements:
 
 - a Linux VM with current Docker Engine and the Compose plugin;
 - DNS for the chosen hostname;
-- an external Docker network named `keycast`;
-- a reverse proxy attached to that network. `caddy-docker-compose-example.yml` is provided.
+- an internal external Docker network named `keycast` (`docker network create --internal keycast`);
+- a reverse proxy attached to that network. `caddy-docker-compose-example.yml` and
+  `Caddyfile.example` are provided and use a static configuration with no Docker socket mount.
 
 Initialize a checkout:
 
@@ -51,9 +52,17 @@ sudo docker compose -f docker-compose.prod.yml pull
 sudo docker compose -f docker-compose.prod.yml up -d
 ```
 
+Then copy `Caddyfile.example` to `Caddyfile`, review it, and start the proxy with
+`docker compose -f caddy-docker-compose-example.yml up -d`.
+
 `ALLOWED_PUBKEYS` is the instance admission allowlist. `KEYCAST_OPERATOR_PUBKEYS` controls global relay changes. It fails closed when absent. Open registration
 exists only as an explicit development escape hatch through `KEYCAST_ALLOW_OPEN_REGISTRATION=true`;
 do not enable it on an Internet-facing instance.
+
+The `keycast` network is internal, so the API and web containers have no route off the host. The
+signer gets its own egress network for relay connections, and the reverse proxy keeps a public
+network for ACME and published ports. Nothing needs inbound access to the signer: the API reaches
+it only through the private socket volume.
 
 The setup creates a 32-byte root key in `master.key`, mode `0600`, and assigns the database and key
 to the fixed container UID/GID `10001`. The file is mounted read-only into the signer only. V2 can
@@ -65,7 +74,15 @@ Production publishes three images:
 - `ghcr.io/marmot-protocol/keycast-api:v2`
 - `ghcr.io/marmot-protocol/keycast-web:v2`
 
-Production Compose requires a SHA-256 manifest digest that has been reviewed for each of the three images.
+Production Compose requires a SHA-256 manifest digest for each of the three images. A digest only
+pins what you already trust, so verify each one was built by this repository before deploying it:
+
+```sh
+gh attestation verify oci://ghcr.io/marmot-protocol/keycast-signer@sha256:... \
+  --repo marmot-protocol/keycast
+```
+
+`scripts/upgrade_preflight.sh` runs that check for all three images when `gh` is installed.
 Use source Compose (`docker compose up -d --build`) for a local build.
 
 ## Operations
@@ -76,6 +93,7 @@ The authenticated **Status** page reports:
 - active grants, sessions, and claimable invitations;
 - enabled and connected relay counts;
 - per-relay connection, receive, publish, failure, and error checkpoints;
+- the management reply identity fingerprint, for comparison against `keycast_signer status`;
 - the last processed request and redacted failure counters.
 
 API health and signing readiness are separate so management remains available during relay outages.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Initialize a checkout:
 ```sh
 bash scripts/init.sh \
   --domain keycast.example.com \
-  --allowed-pubkeys "64-character-hex-pubkey[,another-pubkey]"
+  --allowed-pubkeys "64-character-hex-pubkey[,another-pubkey]" \
+  --state-dir /srv/keycast   # optional; keeps state out of the checkout
 # Set the three reviewed image digests in .env before production preflight/pull.
 sudo scripts/upgrade_preflight.sh --fix-permissions
 sudo docker compose -f docker-compose.prod.yml pull
@@ -65,7 +66,8 @@ network for ACME and published ports. Nothing needs inbound access to the signer
 it only through the private socket volume.
 
 The setup creates a 32-byte root key in `master.key`, mode `0600`, and assigns the database and key
-to the fixed container UID/GID `10001`. The file is mounted read-only into the signer only. V2 can
+to the fixed container UID/GID `10001`. With `--state-dir` (recorded as `KEYCAST_STATE_DIR` in
+`.env`) both live outside the checkout, so no `git` operation or source build can reach them. The file is mounted read-only into the signer only. V2 can
 also load a systemd credential from `$CREDENTIALS_DIRECTORY` when run outside Compose.
 
 Production publishes three images:

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,12 @@ No further timed soaks are planned. The remaining reliability findings stay trac
 as follow-ups; completed soak evidence does not close independent review or recovery work.
 Fresh-install signing defaults are nos.lol, Primal and Damus; Ditto and Bucket are excluded.
 
+September 9 second review pass: the high and medium findings from the signer, web, crypto and
+deployment reviews are fixed and covered by tests. See the second-pass table in `AUDIT.md`.
+The container network is now internal and the reverse proxy no longer takes the Docker socket, so
+an existing deployment needs the one-time steps in the "Hardening migration" section of
+`UPGRADE.md`.
+
 Remaining deployment and independent validation work:
 
 - [ ] Independent review of management kind 27236, signer authorization, NIP-46, envelope encryption,
@@ -32,7 +38,9 @@ Remaining deployment and independent validation work:
   workload: `docs/RELAY_ROLLOUT_2026-09-08.md`.
 - [ ] Complete the VM key-operation matrix below, including encryption/decryption rather than signing alone.
 - [ ] Select off-host backup storage and enable the provided encrypted upload/verification/retention and age-monitoring jobs.
-- [ ] Configure host/proxy connection limits and connect the provided capacity/readiness monitor to an external alert receiver.
+- [ ] Connect the provided capacity/readiness monitor to an external alert receiver. Proxy body and
+  request limits now ship in `Caddyfile.example`; per-IP rate limits still need a Caddy plugin or
+  host firewall, because the API sees only the proxy's address.
 - [ ] Exercise management approvals with the intended external NIP-07/NIP-55/NIP-46 stores.
 - [ ] Evaluate Umbrel/StartOS only after the VM deployment has operating history.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -126,18 +126,33 @@ sudo docker compose -f docker-compose.prod.yml exec -T keycast-signer \
 **Swap is now disabled for the containers.** `memswap_limit` matches `mem_limit` so decrypted key
 material cannot be paged to host swap. No action needed, but confirm the host has enough RAM.
 
-**State can now live outside the checkout.** `KEYCAST_STATE_DIR` moves `database/` and `master.key`
-away from the working tree, so a `git` operation or a source build can never reach them. It defaults
-to the checkout, so existing deployments are unaffected. To move an existing instance, stop the
-stack, move both, and record the new location:
+**State can now live outside the checkout.** `KEYCAST_STATE_DIR` moves the runtime database and
+`master.key` away from the working tree, so a `git` operation or a source build can never reach
+them. It defaults to the checkout, so existing deployments are unaffected.
+
+Move the database *files*, not the `database/` directory: `database/migrations` is tracked source
+that both the image build and the Rust tests read, and relocating it breaks them. The signer reads
+migrations from inside the image, so the external directory holds only the database.
 
 ~~~sh
 sudo docker compose -f docker-compose.prod.yml down
-sudo install -d -m 0700 -o 10001 -g 10001 /srv/keycast
-sudo mv database master.key /srv/keycast/
+sudo install -d -m 0700 -o 10001 -g 10001 /srv/keycast /srv/keycast/database
+sudo mv database/keycast-v2.db* /srv/keycast/database/
+sudo mv master.key /srv/keycast/
 echo "KEYCAST_STATE_DIR=/srv/keycast" | sudo tee -a .env
-sudo scripts/upgrade_preflight.sh --fix-permissions
 ~~~
+
+Stale `database/keycast-v2.*.lock` files can be deleted; the signer recreates them. Then validate
+and restart:
+
+~~~sh
+sudo scripts/upgrade_preflight.sh --fix-permissions
+sudo docker compose -f docker-compose.prod.yml up -d
+sudo docker compose -f docker-compose.prod.yml ps
+~~~
+
+Confirm the signer reports schema version 2 and your existing keys on the **Status** page before
+deleting anything from the old location.
 
 `scripts/init.sh --state-dir /srv/keycast` sets this up for a fresh install, and the preflight
 resolves the same path so it never validates a stale copy.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -98,11 +98,19 @@ sudo docker network create --internal keycast
 **The reverse proxy no longer needs the Docker socket.** The previous example mounted
 `/var/run/docker.sock` into Caddy, which is root-equivalent on the host: read-only applies to the
 socket file, not to the Docker API commands sent over it. The proxy now uses a static file, and the
-`caddy=` labels have been removed from both Compose files.
+`caddy=` labels have been removed from both Compose files. Prepare and review that file before
+starting anything:
 
 ~~~sh
-cp Caddyfile.example Caddyfile   # review it, then
+cp Caddyfile.example Caddyfile
+~~~
+
+Then bring the whole stack back up and confirm it is healthy:
+
+~~~sh
+sudo docker compose -f docker-compose.prod.yml up -d
 sudo docker compose -f caddy-docker-compose-example.yml up -d
+sudo docker compose -f docker-compose.prod.yml ps
 ~~~
 
 **Management writes now pin a reply identity.** The signer derives a stable reply keypair from the
@@ -117,6 +125,22 @@ sudo docker compose -f docker-compose.prod.yml exec -T keycast-signer \
 
 **Swap is now disabled for the containers.** `memswap_limit` matches `mem_limit` so decrypted key
 material cannot be paged to host swap. No action needed, but confirm the host has enough RAM.
+
+**State can now live outside the checkout.** `KEYCAST_STATE_DIR` moves `database/` and `master.key`
+away from the working tree, so a `git` operation or a source build can never reach them. It defaults
+to the checkout, so existing deployments are unaffected. To move an existing instance, stop the
+stack, move both, and record the new location:
+
+~~~sh
+sudo docker compose -f docker-compose.prod.yml down
+sudo install -d -m 0700 -o 10001 -g 10001 /srv/keycast
+sudo mv database master.key /srv/keycast/
+echo "KEYCAST_STATE_DIR=/srv/keycast" | sudo tee -a .env
+sudo scripts/upgrade_preflight.sh --fix-permissions
+~~~
+
+`scripts/init.sh --state-dir /srv/keycast` sets this up for a fresh install, and the preflight
+resolves the same path so it never validates a stale copy.
 
 ## Future V2 Upgrades
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,7 +11,8 @@ Plan a short maintenance window, re-import every key, and reconnect every client
    material into notes.
 3. Optionally archive `database/keycast.db` and the old `master.key` for rollback to V1. They are
    not needed by V2.
-4. Make sure the external `keycast` Docker network and reverse proxy are available.
+4. Make sure the external `keycast` Docker network and reverse proxy are available. The network is
+   now created with `--internal`; see "Hardening migration" below if yours already exists.
 
 ## Replace V1
 
@@ -21,12 +22,13 @@ Stop the old deployment:
 sudo docker compose down
 ~~~
 
-Keep any legacy files as an offline archive if desired:
+Keep any legacy files as an offline archive if desired. Move them **outside** the checkout: a root
+key inside the repository would be copied into the Docker build context by a source build.
 
 ~~~sh
-mkdir -p legacy-v1
-mv database/keycast.db* legacy-v1/ 2>/dev/null || true
-mv master.key legacy-v1/master.key 2>/dev/null || true
+sudo install -d -m 0700 /srv/keycast-legacy-v1
+sudo mv database/keycast.db* /srv/keycast-legacy-v1/ 2>/dev/null || true
+sudo mv master.key /srv/keycast-legacy-v1/master.key 2>/dev/null || true
 ~~~
 
 Create the v2 configuration and a fresh root credential:
@@ -78,11 +80,60 @@ V1 rollback requires the archived V1 database and its matching old root key. Sto
 restoring them. V2 changes made after the cutover do not exist in V1 and cannot be converted back.
 Do not mix a database with a different root credential.
 
+## Hardening migration
+
+These changes tighten the shipped defaults and need one deliberate step each on an existing
+deployment.
+
+**The `keycast` network is now internal.** The API and web containers no longer have a route off
+the host; the signer gets its own egress network. Recreate the network once:
+
+~~~sh
+sudo docker compose -f docker-compose.prod.yml down
+sudo docker compose -f caddy-docker-compose-example.yml down
+sudo docker network rm keycast
+sudo docker network create --internal keycast
+~~~
+
+**The reverse proxy no longer needs the Docker socket.** The previous example mounted
+`/var/run/docker.sock` into Caddy, which is root-equivalent on the host: read-only applies to the
+socket file, not to the Docker API commands sent over it. The proxy now uses a static file, and the
+`caddy=` labels have been removed from both Compose files.
+
+~~~sh
+cp Caddyfile.example Caddyfile   # review it, then
+sudo docker compose -f caddy-docker-compose-example.yml up -d
+~~~
+
+**Management writes now pin a reply identity.** The signer derives a stable reply keypair from the
+root credential and publishes its public half through `/api/config`. Your browser pins it on first
+use. After a root-credential rotation the identity changes, so the Status page shows a warning with
+both fingerprints and a button to trust the new one. Compare it against the host first:
+
+~~~sh
+sudo docker compose -f docker-compose.prod.yml exec -T keycast-signer \
+  /app/keycast_signer status | python3 -m json.tool | grep management_reply
+~~~
+
+**Swap is now disabled for the containers.** `memswap_limit` matches `mem_limit` so decrypted key
+material cannot be paged to host swap. No action needed, but confirm the host has enough RAM.
+
 ## Future V2 Upgrades
 
 Once on v2, preserve `database/keycast-v2.db` and `master.key` together, pin all three images to
-reviewed per-image SHA-256 digests, run `scripts/upgrade_preflight.sh`, pull, and restart. Review release
+per-image SHA-256 digests, run `scripts/upgrade_preflight.sh`, pull, and restart. Review release
 notes for schema changes before every upgrade.
+
+A digest pins only what you already trust, so verify provenance before pinning one. The publish
+workflow attests each image and prints the digests in its run summary:
+
+~~~sh
+gh attestation verify oci://ghcr.io/marmot-protocol/keycast-signer@sha256:... \
+  --repo marmot-protocol/keycast
+~~~
+
+`scripts/upgrade_preflight.sh` performs this check for all three images when `gh` is installed, and
+fails when an image has no verifiable provenance.
 
 The September 5 prerelease authority schema deliberately invalidates earlier V2 migration checksums.
 Choose a fresh development database; no automatic deletion or V1 conversion is performed.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -134,12 +134,24 @@ Move the database *files*, not the `database/` directory: `database/migrations` 
 that both the image build and the Rust tests read, and relocating it breaks them. The signer reads
 migrations from inside the image, so the external directory holds only the database.
 
+The move runs inside one privileged shell. `database/` is mode `0700` owned by UID 10001, so an
+ordinary operator's shell cannot list it to expand the wildcard: bash would pass the literal
+`database/keycast-v2.db*` to `mv` and zsh would refuse outright, and the credential move and `.env`
+edit that follow would still succeed, leaving the database behind and the signer pointed at an empty
+directory. Running the whole move under `sudo bash -euc` expands the glob with the right privileges
+and stops at the first failure.
+
 ~~~sh
 sudo docker compose -f docker-compose.prod.yml down
 sudo install -d -m 0700 -o 10001 -g 10001 /srv/keycast /srv/keycast/database
-sudo mv database/keycast-v2.db* /srv/keycast/database/
-sudo mv master.key /srv/keycast/
-echo "KEYCAST_STATE_DIR=/srv/keycast" | sudo tee -a .env
+sudo bash -euc '
+  shopt -s nullglob
+  database=(database/keycast-v2.db*)
+  (( ${#database[@]} )) || { echo "no keycast-v2.db found to move"; exit 1; }
+  mv -- "${database[@]}" /srv/keycast/database/
+  mv -- master.key /srv/keycast/
+  echo "KEYCAST_STATE_DIR=/srv/keycast" >> .env
+'
 ~~~
 
 Stale `database/keycast-v2.*.lock` files can be deleted; the signer recreates them. Then validate

--- a/api/src/gateway.rs
+++ b/api/src/gateway.rs
@@ -55,7 +55,8 @@ pub async fn forward(State(state): State<KeycastState>, request: Request<Body>) 
             .get("authorization")
             .and_then(|h| h.to_str().ok())
             .map(str::to_owned),
-        body,
+        // A browser key import travels through this body; erase it on drop.
+        body: keycast_core::v2::secret::Secret::new(body),
     };
     match state.signer.request(&request).await {
         Ok(ControlResponse::Http { reply }) => Response::builder()

--- a/caddy-docker-compose-example.yml
+++ b/caddy-docker-compose-example.yml
@@ -1,27 +1,80 @@
+# Reverse proxy for a Keycast instance, using a static Caddyfile.
+#
+# This deliberately does NOT mount /var/run/docker.sock. A label-driven proxy
+# needs the Docker API, and that API is root-equivalent on the host even when the
+# socket is bind-mounted read-only: read-only applies to the socket file, not to
+# the commands sent over it. Caddy is the only process that parses untrusted
+# Internet traffic, so a compromise there would otherwise expose master.key, the
+# database, and the signer. Keycast has two fixed upstreams, so nothing is lost.
+#
+# Setup:
+#   cp Caddyfile.example Caddyfile      # then review it
+#   docker network create --internal keycast   # scripts/init.sh does this
+#   docker compose -f caddy-docker-compose-example.yml up -d
+#
+# Verify the pinned digest before trusting it:
+#   docker buildx imagetools inspect caddy:2.10-alpine
+
 services:
   caddy:
-    image: lucaslorentz/caddy-docker-proxy:2.13.1-alpine@sha256:3e6cf4a6382da0cd14108a69929d7f8cc59e9a59cae4c9795071fa392ffa8036
+    image: caddy:2.10-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
+    container_name: keycast-caddy
     ports:
-      - 80:80
-      - 443:443
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
     environment:
-      - CADDY_INGRESS_NETWORKS=keycast,strfry
+      DOMAIN: "${DOMAIN:?error}"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
+      - caddy_config:/config
     networks:
+      # Reaches keycast-api and keycast-web on the internal network, and the
+      # public network for ACME and published ports.
       - keycast
+      - keycast-ingress
+    read_only: true
+    tmpfs:
+      - /tmp:size=16m,mode=1777,noexec,nosuid,nodev
+    init: true
+    pids_limit: 128
+    mem_limit: 256m
+    memswap_limit: 256m
+    stop_grace_period: 30s
     security_opt:
       - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      # Binding 80 and 443 is the only privilege this needs.
+      - NET_BIND_SERVICE
+    ulimits:
+      core: 0
+      nofile:
+        soft: 8192
+        hard: 8192
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+        compress: "true"
+    healthcheck:
+      test: ["CMD", "caddy", "version"]
+      interval: 30s
+      timeout: 6s
+      retries: 3
+      start_period: 10s
 
 networks:
   keycast:
     external: true
     name: keycast
-  strfry:
-    external: true
-    name: strfry
+  keycast-ingress:
+    driver: bridge
 
 volumes:
   caddy_data:
+  caddy_config:

--- a/core/src/v2/control.rs
+++ b/core/src/v2/control.rs
@@ -1,4 +1,7 @@
+use crate::v2::secret::Secret;
+
 /// Only this authenticated forwarding protocol is exposed on the API socket.
+/// The body is zeroizing because a browser key import travels through it.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(tag = "operation", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ControlRequest {
@@ -6,7 +9,7 @@ pub enum ControlRequest {
         method: String,
         path: String,
         authorization: Option<String>,
-        body: String,
+        body: Secret,
     },
     Status,
 }
@@ -33,7 +36,7 @@ pub enum LifecycleRequest {
         team_id: i64,
         actor_public_key: String,
         name: String,
-        secret_key: String,
+        secret_key: Secret,
     },
     CreateGrant {
         team_id: i64,
@@ -122,6 +125,9 @@ pub struct SignerStatus {
     pub schema_version: i64,
     pub envelope_version: i64,
     pub credential_key_id: Option<String>,
+    /// Stable identity that encrypts management replies. Public, and shown so an
+    /// operator can compare the browser's pinned value against the host CLI.
+    pub management_reply_public_key: Option<String>,
     pub active_grants: i64,
     pub active_sessions: i64,
     pub claimable_invitations: i64,

--- a/core/src/v2/envelope.rs
+++ b/core/src/v2/envelope.rs
@@ -11,6 +11,8 @@ use zeroize::Zeroizing;
 use super::ENVELOPE_VERSION;
 
 const NONCE_LEN: usize = 12;
+/// Domain separator for the stable management-reply identity derived from the root credential.
+const REPLY_IDENTITY_INFO: &[u8] = b"keycast-management-reply-v1";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnvelopeContext<'a> {
@@ -24,6 +26,8 @@ pub struct EnvelopeContext<'a> {
 pub struct EnvelopeCipher {
     cipher: Aes256Gcm,
     key_id: String,
+    /// Seed for the stable management-reply identity. Never leaves this type.
+    reply_seed: Zeroizing<[u8; 32]>,
 }
 
 #[derive(Debug, Error)]
@@ -36,6 +40,8 @@ pub enum EnvelopeError {
     Read(#[from] std::io::Error),
     #[error("root credential must be 32 bytes encoded as base64 or hex")]
     InvalidCredential,
+    #[error("both CREDENTIALS_DIRECTORY and KEYCAST_ROOT_KEY_FILE are set; unset one so the root credential source is unambiguous")]
+    AmbiguousCredential,
     #[error("encrypted envelope is truncated")]
     Truncated,
     #[error("envelope encryption failed")]
@@ -46,6 +52,13 @@ pub enum EnvelopeError {
 
 impl EnvelopeCipher {
     pub fn load() -> Result<Self, EnvelopeError> {
+        // The systemd credential used to win silently. Loading the wrong key fails
+        // closed later, but an ambiguous configuration should be rejected outright.
+        if std::env::var_os("CREDENTIALS_DIRECTORY").is_some()
+            && std::env::var_os("KEYCAST_ROOT_KEY_FILE").is_some()
+        {
+            return Err(EnvelopeError::AmbiguousCredential);
+        }
         let path = credential_path().ok_or(EnvelopeError::CredentialNotFound)?;
         Self::from_file(&path)
     }
@@ -63,12 +76,49 @@ impl EnvelopeCipher {
             .iter()
             .map(|byte| format!("{byte:02x}"))
             .collect();
+        // Domain-separated derivation. Publishing the reply public key reveals
+        // nothing about the root credential, and the seed is never exported.
+        let mut reply_seed = Zeroizing::new([0_u8; 32]);
+        let mut hasher = Sha256::new();
+        hasher.update(REPLY_IDENTITY_INFO);
+        hasher.update(key.as_ref());
+        reply_seed.copy_from_slice(&hasher.finalize());
         let cipher = Aes256Gcm::new((&*key).into());
-        Self { cipher, key_id }
+        Self {
+            cipher,
+            key_id,
+            reply_seed,
+        }
     }
 
     pub fn key_id(&self) -> &str {
         &self.key_id
+    }
+
+    /// Stable identity used to encrypt management replies, so a browser can
+    /// authenticate their origin instead of trusting a per-reply ephemeral key.
+    pub fn management_reply_keys(&self) -> Result<nostr::prelude::Keys, EnvelopeError> {
+        let mut candidate = self.reply_seed.clone();
+        // A SHA-256 digest is a valid secp256k1 scalar with overwhelming probability;
+        // rehash on the astronomically unlikely miss rather than failing the instance.
+        for attempt in 0_u8..=8 {
+            if let Ok(secret) = nostr::prelude::SecretKey::from_slice(candidate.as_ref()) {
+                return Ok(nostr::prelude::Keys::new(secret));
+            }
+            let mut hasher = Sha256::new();
+            hasher.update(REPLY_IDENTITY_INFO);
+            hasher.update([attempt]);
+            hasher.update(candidate.as_ref());
+            candidate.copy_from_slice(&hasher.finalize());
+        }
+        Err(EnvelopeError::InvalidCredential)
+    }
+
+    /// Hex public key of [`Self::management_reply_keys`], safe to publish.
+    pub fn management_reply_public_key(&self) -> Option<String> {
+        self.management_reply_keys()
+            .ok()
+            .map(|keys| keys.public_key().to_hex())
     }
 
     pub fn seal(
@@ -151,7 +201,8 @@ fn decode_root_key(encoded: &str) -> Result<Zeroizing<[u8; 32]>, EnvelopeError> 
 }
 
 fn decode_hex(value: &str) -> Result<Vec<u8>, ()> {
-    if value.len() != 64 {
+    // `from_str_radix` accepts a leading sign, so require strict hex digits first.
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err(());
     }
     value
@@ -168,8 +219,11 @@ fn decode_hex(value: &str) -> Result<Vec<u8>, ()> {
 fn ensure_private_permissions(path: &Path) -> Result<(), EnvelopeError> {
     use std::os::unix::fs::PermissionsExt;
 
-    let mode = fs::metadata(path)?.permissions().mode();
-    if mode & 0o077 != 0 {
+    let metadata = fs::metadata(path)?;
+    if !metadata.is_file() {
+        return Err(EnvelopeError::InvalidCredential);
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
         return Err(EnvelopeError::InsecurePermissions(path.to_path_buf()));
     }
     Ok(())
@@ -215,10 +269,61 @@ mod tests {
         assert!(!cipher().key_id().contains("0707"));
     }
     #[test]
+    fn management_reply_identity_is_stable_distinct_and_hides_the_root() {
+        let first = cipher();
+        let again = EnvelopeCipher::from_key(Zeroizing::new([7_u8; 32]));
+        let other = EnvelopeCipher::from_key(Zeroizing::new([8_u8; 32]));
+
+        let public = first.management_reply_public_key().expect("reply identity");
+        assert_eq!(public.len(), 64);
+        assert_eq!(
+            public,
+            again
+                .management_reply_public_key()
+                .expect("stable identity")
+        );
+        assert_ne!(
+            public,
+            other.management_reply_public_key().expect("reply identity")
+        );
+
+        // The published identity must not disclose the root credential or its fingerprint.
+        let secret = first
+            .management_reply_keys()
+            .expect("reply identity")
+            .secret_key()
+            .to_secret_hex();
+        assert_ne!(secret, "07".repeat(32));
+        assert!(!public.contains(first.key_id()));
+        assert!(!secret.contains("0707070707"));
+    }
+
+    #[test]
+    fn both_credential_sources_set_is_rejected_instead_of_silently_preferring_one() {
+        // These variables are not read by any other test in this crate.
+        static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _lock = GUARD.lock().unwrap();
+        std::env::set_var("CREDENTIALS_DIRECTORY", "/run/credentials/keycast");
+        std::env::set_var("KEYCAST_ROOT_KEY_FILE", "/run/secrets/keycast-root-key");
+        assert!(matches!(
+            EnvelopeCipher::load(),
+            Err(EnvelopeError::AmbiguousCredential)
+        ));
+        std::env::remove_var("CREDENTIALS_DIRECTORY");
+        std::env::remove_var("KEYCAST_ROOT_KEY_FILE");
+        assert!(matches!(
+            EnvelopeCipher::load(),
+            Err(EnvelopeError::CredentialNotFound)
+        ));
+    }
+
+    #[test]
     fn root_decoder_accepts_hex_and_base64_and_rejects_invalid_lengths() {
         assert_eq!(*decode_root_key(&"07".repeat(32)).unwrap(), [7; 32]);
         assert_eq!(*decode_root_key(&BASE64.encode([7; 32])).unwrap(), [7; 32]);
         assert!(decode_root_key(&"x".repeat(64)).is_err());
+        // A signed hex pair must not be accepted as a byte.
+        assert!(decode_root_key(&format!("+f{}", "0".repeat(62))).is_err());
         assert!(decode_root_key(&BASE64.encode([7; 31])).is_err());
     }
 }

--- a/core/src/v2/management.rs
+++ b/core/src/v2/management.rs
@@ -31,18 +31,35 @@ pub fn approval_context(event: &Event, instance: &str, revision: i64) -> Option<
     PublicKey::from_hex(exact_tag(event, "response")?).ok()
 }
 
+/// Substrings that must never reach an approval event an external signer
+/// displays, stores, or transports over relays.
+const SECRET_MARKERS: [&str; 2] = ["secret_key", "nsec1"];
+
+/// Deserializing only the name lets serde skip the private field without
+/// allocating it, unlike parsing the whole body into a `Value`.
+#[derive(serde::Deserialize)]
+struct ImportedKeyName {
+    name: String,
+}
+
 /// Human-readable, verified command contents for the external approval screen.
 /// Private import material must never be copied into an approval event.
 pub fn description(method: &str, path: &str, body: &str) -> Option<String> {
     if method == "POST" && path.split('?').next()?.ends_with("/keys") {
-        let value: serde_json::Value = serde_json::from_str(body).ok()?;
-        Some(format!(
-            "Import private key named {}",
-            value.get("name")?.as_str()?
-        ))
+        let request: ImportedKeyName = serde_json::from_str(body).ok()?;
+        Some(format!("Import private key named {}", request.name))
     } else {
         Some(body.to_owned())
     }
+}
+
+/// Fail closed instead of letting a route echo private material into an approval.
+/// Guards both the redacted import summary and any future write whose body is echoed.
+pub fn contains_secret_marker(content: &str) -> bool {
+    let lowered = content.to_ascii_lowercase();
+    SECRET_MARKERS
+        .iter()
+        .any(|marker| lowered.contains(*marker))
 }
 
 #[cfg(test)]
@@ -55,6 +72,31 @@ mod tests {
             .finalize(&Keys::generate())
             .unwrap()
     }
+    #[test]
+    fn import_description_names_the_key_without_its_private_material() {
+        let body = r#"{"name":"Personal identity","secret_key":"nsec1exampleprivatematerial"}"#;
+        let description = description("POST", "/teams/1/keys", body).unwrap();
+        assert_eq!(description, "Import private key named Personal identity");
+        assert!(!description.contains("nsec1"));
+        assert!(!contains_secret_marker(&description));
+    }
+
+    #[test]
+    fn secret_markers_are_detected_in_echoed_bodies_and_pasted_names() {
+        // A future route that echoes its body must not ship private material.
+        let echoed = description("PUT", "/teams/1", r#"{"secret_key":"nsec1abc"}"#).unwrap();
+        assert!(contains_secret_marker(&echoed));
+        // An operator pasting a private key into the name field is caught too.
+        let pasted = description(
+            "POST",
+            "/teams/1/keys",
+            r#"{"name":"NSEC1abc","secret_key":"x"}"#,
+        )
+        .unwrap();
+        assert!(contains_secret_marker(&pasted));
+        assert!(!contains_secret_marker(r#"{"name":"Ops"}"#));
+    }
+
     #[test]
     fn approval_context_rejects_cross_instance_revision_and_ambiguous_tags() {
         let response = Keys::generate().public_key();

--- a/core/src/v2/management.rs
+++ b/core/src/v2/management.rs
@@ -72,6 +72,23 @@ mod tests {
             .finalize(&Keys::generate())
             .unwrap()
     }
+    /// The browser refuses to sign first, so a marker present only here would let
+    /// content the signer rejects still reach an external key store. The list is
+    /// read from the TypeScript source rather than duplicated in this test.
+    #[test]
+    fn secret_markers_match_the_browser_list() {
+        let typescript = include_str!("../../../web/src/lib/utils/management.ts");
+        let declaration = typescript
+            .lines()
+            .find(|line| line.contains("const SECRET_MARKERS"))
+            .expect("web/src/lib/utils/management.ts declares SECRET_MARKERS");
+        let browser: Vec<&str> = declaration.split('"').skip(1).step_by(2).collect();
+        assert_eq!(
+            browser, SECRET_MARKERS,
+            "the browser and signer marker lists have diverged"
+        );
+    }
+
     #[test]
     fn import_description_names_the_key_without_its_private_material() {
         let body = r#"{"name":"Personal identity","secret_key":"nsec1exampleprivatematerial"}"#;

--- a/core/src/v2/mod.rs
+++ b/core/src/v2/mod.rs
@@ -1,6 +1,7 @@
 pub mod control;
 pub mod envelope;
 pub mod policy;
+pub mod secret;
 pub mod team_slug;
 
 pub const SCHEMA_VERSION: i64 = 2;

--- a/core/src/v2/secret.rs
+++ b/core/src/v2/secret.rs
@@ -1,0 +1,90 @@
+//! Zeroizing wrapper for private material that crosses the API and control boundaries.
+//!
+//! The wrapper narrows, but does not eliminate, plaintext lifetime: intermediate
+//! copies inside third-party HTTP and JSON machinery cannot be erased from here.
+//! Browser import therefore remains the weaker path; the trusted CLI stays preferred
+//! for sensitive keys.
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::Zeroizing;
+
+/// A string whose buffer is erased on drop and never rendered by `Debug`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Secret(Zeroizing<String>);
+
+impl Secret {
+    pub fn new(value: String) -> Self {
+        Self(Zeroizing::new(value))
+    }
+
+    pub fn expose(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn into_zeroizing(self) -> Zeroizing<String> {
+        self.0
+    }
+}
+
+impl From<String> for Secret {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Never render private material, including through `{:?}` on a containing struct.
+impl fmt::Debug for Secret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("Secret(<redacted>)")
+    }
+}
+
+impl<'de> Deserialize<'de> for Secret {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // The deserialized allocation is moved into the zeroizing buffer, not copied.
+        String::deserialize(deserializer).map(Self::new)
+    }
+}
+
+impl Serialize for Secret {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.expose())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_never_renders_the_value() {
+        let secret = Secret::new("nsec1exampleprivatematerial".to_string());
+        assert_eq!(format!("{secret:?}"), "Secret(<redacted>)");
+        assert!(!format!("{secret:?}").contains("nsec1"));
+        assert_eq!(secret.expose(), "nsec1exampleprivatematerial");
+    }
+
+    #[test]
+    fn round_trips_through_serde_without_exposing_debug() {
+        #[derive(Debug, Deserialize, Serialize)]
+        struct Request {
+            secret_key: Secret,
+        }
+        let request: Request = serde_json::from_str(r#"{"secret_key":"nsec1abc"}"#).unwrap();
+        assert_eq!(request.secret_key.expose(), "nsec1abc");
+        assert!(!format!("{request:?}").contains("nsec1abc"));
+        assert_eq!(
+            serde_json::to_string(&request).unwrap(),
+            r#"{"secret_key":"nsec1abc"}"#
+        );
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,10 +2,13 @@ x-keycast-hardening: &keycast-hardening
   user: "10001:10001"
   read_only: true
   tmpfs:
-    - /tmp:size=64m,mode=1777
+    - /tmp:size=64m,mode=1777,noexec,nosuid,nodev
   init: true
   pids_limit: 128
   mem_limit: 512m
+  # Equal to mem_limit: disables swap for the cgroup so decrypted key material
+  # cannot be paged to host swap, which would outlive the container.
+  memswap_limit: 512m
   stop_grace_period: 30s
   security_opt:
     - no-new-privileges:true
@@ -17,8 +20,6 @@ x-keycast-hardening: &keycast-hardening
       soft: 4096
       hard: 4096
   restart: unless-stopped
-  networks:
-    - keycast
   logging:
     driver: json-file
     options:
@@ -30,11 +31,16 @@ services:
   keycast-signer:
     <<: *keycast-hardening
     container_name: keycast-signer
+    # Reachable by nothing: the API talks to it only over the socket volume.
+    networks:
+      - keycast-signer-egress
     image: "${KEYCAST_SIGNER_IMAGE:-ghcr.io/marmot-protocol/keycast-signer}@${KEYCAST_SIGNER_DIGEST:?set reviewed signer image digest}"
     volumes:
-      - ./database:/app/database:rw
+      # Set KEYCAST_STATE_DIR to keep persistent state and the root credential
+      # outside the checkout, e.g. /srv/keycast. Defaults to the checkout.
+      - ${KEYCAST_STATE_DIR:-.}/database:/app/database:rw
       - keycast-runtime:/run/keycast:rw
-      - ./master.key:/run/secrets/keycast-root-key:ro
+      - ${KEYCAST_STATE_DIR:-.}/master.key:/run/secrets/keycast-root-key:ro
     environment:
       RUST_LOG: info,keycast_signer=info
       ALLOWED_PUBKEYS: "${ALLOWED_PUBKEYS:?error}"
@@ -50,6 +56,8 @@ services:
   keycast-api:
     <<: *keycast-hardening
     container_name: keycast-api
+    networks:
+      - keycast
     image: "${KEYCAST_API_IMAGE:-ghcr.io/marmot-protocol/keycast-api}@${KEYCAST_API_DIGEST:?set reviewed api image digest}"
     expose:
       - "3000"
@@ -67,13 +75,12 @@ services:
       timeout: 6s
       retries: 3
       start_period: 10s
-    labels:
-      - "caddy=${DOMAIN:?error}"
-      - "caddy.reverse_proxy=/api/* {{upstreams 3000}}"
 
   keycast-web:
     <<: *keycast-hardening
     container_name: keycast-web
+    networks:
+      - keycast
     image: "${KEYCAST_WEB_IMAGE:-ghcr.io/marmot-protocol/keycast-web}@${KEYCAST_WEB_DIGEST:?set reviewed web image digest}"
     expose:
       - "5173"
@@ -91,14 +98,17 @@ services:
       timeout: 6s
       retries: 3
       start_period: 10s
-    labels:
-      - "caddy=${DOMAIN:?error}"
-      - "caddy.reverse_proxy=/* {{upstreams 5173}}"
 
 networks:
+  # Created by scripts/init.sh as an internal network: api and web have no route
+  # off-host, so a compromise of the public transport cannot exfiltrate outward.
+  # The reverse proxy joins this network and keeps its own egress network.
   keycast:
     external: true
     name: keycast
+  # Only the signer needs outbound access, for relay connections.
+  keycast-signer-egress:
+    driver: bridge
 
 volumes:
   keycast-runtime:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,13 @@ x-keycast-hardening: &keycast-hardening
   user: "10001:10001"
   read_only: true
   tmpfs:
-    - /tmp:size=64m,mode=1777
+    - /tmp:size=64m,mode=1777,noexec,nosuid,nodev
   init: true
   pids_limit: 128
   mem_limit: 512m
+  # Equal to mem_limit: disables swap for the cgroup so decrypted key material
+  # cannot be paged to host swap, which would outlive the container.
+  memswap_limit: 512m
   stop_grace_period: 30s
   security_opt:
     - no-new-privileges:true
@@ -17,8 +20,6 @@ x-keycast-hardening: &keycast-hardening
       soft: 4096
       hard: 4096
   restart: unless-stopped
-  networks:
-    - keycast
   logging:
     driver: json-file
     options:
@@ -33,13 +34,18 @@ services:
   keycast-signer:
     <<: *keycast-hardening
     container_name: keycast-signer
+    # Reachable by nothing: the API talks to it only over the socket volume.
+    networks:
+      - keycast-signer-egress
     build:
       <<: *rust-build
       target: signer-runtime
     volumes:
-      - ./database:/app/database:rw
+      # Set KEYCAST_STATE_DIR to keep persistent state and the root credential
+      # outside the checkout, e.g. /srv/keycast. Defaults to the checkout.
+      - ${KEYCAST_STATE_DIR:-.}/database:/app/database:rw
       - keycast-runtime:/run/keycast:rw
-      - ./master.key:/run/secrets/keycast-root-key:ro
+      - ${KEYCAST_STATE_DIR:-.}/master.key:/run/secrets/keycast-root-key:ro
     environment:
       RUST_LOG: info,keycast_signer=info
       ALLOWED_PUBKEYS: "${ALLOWED_PUBKEYS:?error}"
@@ -55,6 +61,8 @@ services:
   keycast-api:
     <<: *keycast-hardening
     container_name: keycast-api
+    networks:
+      - keycast
     build:
       <<: *rust-build
       target: api-runtime
@@ -74,13 +82,12 @@ services:
       timeout: 6s
       retries: 3
       start_period: 10s
-    labels:
-      - "caddy=${DOMAIN:?error}"
-      - "caddy.reverse_proxy=/api/* {{upstreams 3000}}"
 
   keycast-web:
     <<: *keycast-hardening
     container_name: keycast-web
+    networks:
+      - keycast
     build:
       context: .
       target: web-runtime
@@ -102,14 +109,17 @@ services:
       timeout: 6s
       retries: 3
       start_period: 10s
-    labels:
-      - "caddy=${DOMAIN:?error}"
-      - "caddy.reverse_proxy=/* {{upstreams 5173}}"
 
 networks:
+  # Created by scripts/init.sh as an internal network: api and web have no route
+  # off-host, so a compromise of the public transport cannot exfiltrate outward.
+  # The reverse proxy joins this network and keeps its own egress network.
   keycast:
     external: true
     name: keycast
+  # Only the signer needs outbound access, for relay connections.
+  keycast-signer-egress:
+    driver: bridge
 
 volumes:
   keycast-runtime:

--- a/docs/V2_OPERATIONS.md
+++ b/docs/V2_OPERATIONS.md
@@ -174,7 +174,9 @@ Set `KEYCAST_DATABASE_PATH`, `KEYCAST_ROOT_KEY_FILE`, `KEYCAST_MIGRATIONS_PATH`,
 and `RCLONE_CONFIG` in the private host environment file. With Docker, set `signer_command` to an
 argument array for `docker compose run --rm --no-deps -T` with the signer service and explicit backup
 key/directory mounts. Those paths must resolve identically to the paths in the job configuration.
-Set `status_command` to `docker compose exec -T signer /app/keycast_signer`. The example service assumes
+Set `status_command` to `docker compose exec -T keycast-signer /app/keycast_signer`. Note that this
+requires the `keycast` user to be in the `docker` group, which is root-equivalent on the host and
+undoes the systemd sandboxing; prefer a host binary. The example service assumes
 a host binary; adapt its account and filesystem permissions to the actual deployment. Docker access
 is trusted host administration, not an additional security boundary.
 

--- a/docs/systemd/README.md
+++ b/docs/systemd/README.md
@@ -1,0 +1,29 @@
+# Host operation units
+
+These are templates. Review every path before enabling them.
+
+`operations.example.json` assumes the signer is a **host binary** at
+`/usr/local/bin/keycast_signer`. Keep it that way if you can: pointing
+`signer_command` at `docker compose run ...` requires `User=keycast` to be in the
+`docker` group, which is root-equivalent on the host and defeats every sandboxing
+directive in these units.
+
+Both units are sandboxed with `ProtectSystem=strict`, an empty capability
+bounding set, a `@system-service` syscall filter, and write access only to the
+specific paths each job needs:
+
+- backup: writes the encrypted archive and the transient snapshot, so it needs
+  `/srv/keycast/database` and `/srv/keycast/backups`.
+- monitor: writes nothing; it needs `/run/keycast` only because connecting to a
+  Unix socket requires write permission on the socket inode.
+
+Adjust `ReadWritePaths=`, `ReadOnlyPaths=` and `backup_key_file` to your layout.
+Verify the result with:
+
+```sh
+systemd-analyze security keycast-backup.service
+systemd-analyze security keycast-monitor.service
+```
+
+Configure `OnFailure=` on both units to reach your alert receiver before you rely
+on them. A backup job that fails silently is not a backup.

--- a/docs/systemd/keycast-backup.service
+++ b/docs/systemd/keycast-backup.service
@@ -9,9 +9,36 @@ Group=keycast
 UMask=0077
 EnvironmentFile=/etc/keycast/host-operations.env
 ExecStart=/usr/bin/python3 /opt/keycast/scripts/operations/keycast_ops.py backup /etc/keycast/operations.json
+TimeoutStartSec=1h
+
+# The backup CLI reads the database and root credential and writes an encrypted
+# archive, so it needs the database directory (the snapshot is written beside the
+# database) and the backup directory, and nothing else.
+ReadWritePaths=/srv/keycast/database /srv/keycast/backups
+ReadOnlyPaths=/secure/keycast-backup.key
+
 NoNewPrivileges=yes
 PrivateTmp=yes
+PrivateDevices=yes
 ProtectHome=yes
 ProtectSystem=strict
-ReadWritePaths=/srv/keycast /run/keycast
-TimeoutStartSec=1h
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
+ProcSubset=pid
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
+# Unix for the signer socket; INET for the off-host upload.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources @obsolete

--- a/docs/systemd/keycast-monitor.service
+++ b/docs/systemd/keycast-monitor.service
@@ -9,9 +9,34 @@ Group=keycast
 UMask=0077
 EnvironmentFile=/etc/keycast/host-operations.env
 ExecStart=/usr/bin/python3 /opt/keycast/scripts/operations/keycast_ops.py monitor /etc/keycast/operations.json
+TimeoutStartSec=15m
+
+# The monitor only reads status and checks backup freshness. Connecting to the
+# signer socket needs write access on the socket itself, nothing else.
+ReadWritePaths=/run/keycast
+ReadOnlyPaths=/srv/keycast
+
 NoNewPrivileges=yes
 PrivateTmp=yes
+PrivateDevices=yes
 ProtectHome=yes
 ProtectSystem=strict
-ReadWritePaths=/srv/keycast /run/keycast
-TimeoutStartSec=1h
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
+ProcSubset=pid
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources @obsolete

--- a/scripts/check-compose-hardening.sh
+++ b/scripts/check-compose-hardening.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Asserts the shipped Compose defaults still carry their hardening. Run by CI and
+# usable directly after editing a Compose file.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Placeholders only; these render the files, they are never deployed.
+export DOMAIN="${DOMAIN:-keycast.example}"
+export ALLOWED_PUBKEYS="${ALLOWED_PUBKEYS:-$(printf '0%.0s' {1..63})1}"
+export KEYCAST_OPERATOR_PUBKEYS="${KEYCAST_OPERATOR_PUBKEYS:-$ALLOWED_PUBKEYS}"
+export KEYCAST_API_DIGEST="${KEYCAST_API_DIGEST:-sha256:$(printf '1%.0s' {1..64})}"
+export KEYCAST_SIGNER_DIGEST="${KEYCAST_SIGNER_DIGEST:-sha256:$(printf '2%.0s' {1..64})}"
+export KEYCAST_WEB_DIGEST="${KEYCAST_WEB_DIGEST:-sha256:$(printf '3%.0s' {1..64})}"
+
+COMPOSE_FILES=(docker-compose.yml docker-compose.prod.yml caddy-docker-compose-example.yml)
+failures=0
+fail() {
+    failures=$((failures + 1))
+    echo "[fail] $1"
+}
+ok() { echo "[ok] $1"; }
+
+for file in "${COMPOSE_FILES[@]}"; do
+    docker compose -f "$file" config --quiet || fail "$file does not render"
+done
+ok "all Compose files render"
+
+rendered="$(docker compose -f docker-compose.yml config)"
+
+# Swap must be disabled wherever plaintext key material can live, and no service
+# may run with a writable root filesystem.
+for setting in memswap_limit read_only; do
+    if [[ "$(printf '%s' "$rendered" | grep -c "$setting")" -ge 3 ]]; then
+        ok "$setting is set on every service"
+    else
+        fail "$setting is missing from at least one service"
+    fi
+done
+
+if printf '%s' "$rendered" | grep -q 'noexec,nosuid,nodev'; then
+    ok "tmpfs mounts are noexec, nosuid and nodev"
+else
+    fail "tmpfs mounts are not hardened"
+fi
+
+# The signer holds the keys and needs no inbound path, so it must not sit on the
+# ingress network beside the public transport.
+if printf '%s' "$rendered" | grep -q 'keycast-signer-egress'; then
+    ok "the signer uses its own egress network"
+else
+    fail "the signer egress network is missing"
+fi
+
+# Inspect rendered mounts, never file text: the proxy example documents the
+# removal of the socket mount in a comment that a text search would match.
+for file in "${COMPOSE_FILES[@]}"; do
+    if docker compose -f "$file" config --format json |
+        python3 -c '
+import json, sys
+
+config = json.load(sys.stdin)
+mounts = []
+for name, service in config.get("services", {}).items():
+    for volume in service.get("volumes", []):
+        if isinstance(volume, dict):
+            mount = "{}:{}".format(volume.get("source", ""), volume.get("target", ""))
+        else:
+            mount = str(volume)
+        if "docker.sock" in mount:
+            mounts.append("{} -> {}".format(name, mount))
+if mounts:
+    print("; ".join(mounts))
+    sys.exit(1)
+'; then
+        ok "$file mounts no Docker socket"
+    else
+        fail "$file mounts the Docker socket"
+    fi
+done
+
+# A denylist silently misses nested paths such as legacy-v1/master.key.
+if grep -qx '\*' .dockerignore; then
+    ok ".dockerignore is allowlist form"
+else
+    fail ".dockerignore is not allowlist form"
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+    echo "Compose hardening checks failed with $failures issue(s)."
+    exit 1
+fi
+echo "Compose hardening checks passed."

--- a/scripts/check-compose-hardening.sh
+++ b/scripts/check-compose-hardening.sh
@@ -15,6 +15,9 @@ export KEYCAST_SIGNER_DIGEST="${KEYCAST_SIGNER_DIGEST:-sha256:$(printf '2%.0s' {
 export KEYCAST_WEB_DIGEST="${KEYCAST_WEB_DIGEST:-sha256:$(printf '3%.0s' {1..64})}"
 
 COMPOSE_FILES=(docker-compose.yml docker-compose.prod.yml caddy-docker-compose-example.yml)
+# Production is what operators actually deploy, so it must carry the same
+# per-service hardening as the source Compose file.
+APPLICATION_COMPOSE_FILES=(docker-compose.yml docker-compose.prod.yml)
 failures=0
 fail() {
     failures=$((failures + 1))
@@ -27,31 +30,33 @@ for file in "${COMPOSE_FILES[@]}"; do
 done
 ok "all Compose files render"
 
-rendered="$(docker compose -f docker-compose.yml config)"
+for file in "${APPLICATION_COMPOSE_FILES[@]}"; do
+    rendered="$(docker compose -f "$file" config)"
 
-# Swap must be disabled wherever plaintext key material can live, and no service
-# may run with a writable root filesystem.
-for setting in memswap_limit read_only; do
-    if [[ "$(printf '%s' "$rendered" | grep -c "$setting")" -ge 3 ]]; then
-        ok "$setting is set on every service"
+    # Swap must be disabled wherever plaintext key material can live, and no
+    # service may run with a writable root filesystem.
+    for setting in memswap_limit read_only; do
+        if [[ "$(printf '%s' "$rendered" | grep -c "$setting")" -ge 3 ]]; then
+            ok "$file: $setting is set on every service"
+        else
+            fail "$file: $setting is missing from at least one service"
+        fi
+    done
+
+    if printf '%s' "$rendered" | grep -q 'noexec,nosuid,nodev'; then
+        ok "$file: tmpfs mounts are noexec, nosuid and nodev"
     else
-        fail "$setting is missing from at least one service"
+        fail "$file: tmpfs mounts are not hardened"
+    fi
+
+    # The signer holds the keys and needs no inbound path, so it must not sit on
+    # the ingress network beside the public transport.
+    if printf '%s' "$rendered" | grep -q 'keycast-signer-egress'; then
+        ok "$file: the signer uses its own egress network"
+    else
+        fail "$file: the signer egress network is missing"
     fi
 done
-
-if printf '%s' "$rendered" | grep -q 'noexec,nosuid,nodev'; then
-    ok "tmpfs mounts are noexec, nosuid and nodev"
-else
-    fail "tmpfs mounts are not hardened"
-fi
-
-# The signer holds the keys and needs no inbound path, so it must not sit on the
-# ingress network beside the public transport.
-if printf '%s' "$rendered" | grep -q 'keycast-signer-egress'; then
-    ok "the signer uses its own egress network"
-else
-    fail "the signer egress network is missing"
-fi
 
 # Inspect rendered mounts, never file text: the proxy example documents the
 # removal of the socket mount in a comment that a text search would match.

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -17,7 +17,7 @@ common=(--detach --read-only --user 10001:10001 --cap-drop ALL --security-opt no
 docker run "${common[@]}" --name "$smoke_id-signer" --network-alias signer -v "$smoke_id-db:/app/database" -v "$smoke_id-runtime:/run/keycast" -v "$smoke_id-root:/run/secrets:ro" -e KEYCAST_ROOT_KEY_FILE=/run/secrets/root.key -e KEYCAST_PUBLIC_URL=https://keycast.test/api -e ALLOWED_PUBKEYS="$operator" -e KEYCAST_OPERATOR_PUBKEYS="$operator" keycast-hardening-signer:local >/dev/null
 docker run "${common[@]}" --name "$smoke_id-api" --network-alias api -v "$smoke_id-runtime:/run/keycast:ro" keycast-hardening-api:local >/dev/null
 docker run "${common[@]}" --name "$smoke_id-web" --network-alias web -e ORIGIN=https://keycast.test keycast-hardening-web:local >/dev/null
-for attempt in $(seq 1 30); do
+for _ in $(seq 1 30); do
   if docker exec "$smoke_id-signer" /app/keycast_signer healthcheck >/dev/null 2>&1 && docker exec "$smoke_id-api" /app/keycast_api healthcheck >/dev/null 2>&1; then break; fi
   sleep 1
 done

--- a/scripts/generate_key.sh
+++ b/scripts/generate_key.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 umask 077
 
-KEY_FILE="master.key"
+# init.sh sets this when state lives outside the checkout.
+KEY_FILE="${KEYCAST_ROOT_KEY_PATH:-master.key}"
 
 # Never offer an overwrite shortcut: replacing this file makes every stored key undecryptable.
 if [ -f "$KEY_FILE" ]; then
@@ -10,7 +11,8 @@ if [ -f "$KEY_FILE" ]; then
     exit 1
 fi
 
-temporary_key=$(mktemp "./.keycast-root.XXXXXX")
+key_directory="$(cd "$(dirname "$KEY_FILE")" && pwd)"
+temporary_key=$(mktemp "$key_directory/.keycast-root.XXXXXX")
 trap 'rm -f "$temporary_key"' EXIT
 
 # Generate a 32-byte (256-bit) random key using openssl and base64 encode it

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -61,7 +61,7 @@ DATABASE_DIR="$STATE_DIR/database"
 ROOT_KEY="$STATE_DIR/master.key"
 mkdir -p "$STATE_DIR"
 if [[ ! -f "$ROOT_KEY" ]]; then
-    KEYCAST_ROOT_KEY_PATH="$ROOT_KEY" bash scripts/generate_key.sh
+    KEYCAST_ROOT_KEY_PATH="$ROOT_KEY" bash "$ROOT_DIR/scripts/generate_key.sh"
 fi
 mkdir -p "$DATABASE_DIR"
 chmod 700 "$DATABASE_DIR"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -71,7 +71,16 @@ fi
 chmod 600 .env
 
 if command -v docker >/dev/null 2>&1; then
-    docker network inspect keycast >/dev/null 2>&1 || docker network create keycast >/dev/null
+    # Internal: keycast-api and keycast-web get no route off-host. The signer uses
+    # its own egress network and the reverse proxy keeps a public one.
+    if ! docker network inspect keycast >/dev/null 2>&1; then
+        docker network create --internal keycast >/dev/null
+    elif [ "$(docker network inspect keycast --format '{{.Internal}}' 2>/dev/null)" != "true" ]; then
+        echo "Warning: the existing 'keycast' network is not internal."
+        echo "To isolate the API and web containers, recreate it after stopping the stack:"
+        echo "  docker compose -f docker-compose.prod.yml down"
+        echo "  docker network rm keycast && docker network create --internal keycast"
+    fi
 fi
 
 echo "Keycast v2 initialized for $DOMAIN."

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -7,9 +7,11 @@ ALLOWED_PUBKEYS=""
 OPERATOR_PUBKEYS=""
 KEYCAST_UID=10001
 KEYCAST_GID=10001
+STATE_DIR_ARG=""
 
 usage() {
-    echo "Usage: $0 --domain <domain> --allowed-pubkeys <hex[,hex...]> [--operator-pubkeys <hex[,hex...]>]"
+    echo "Usage: $0 --domain <domain> --allowed-pubkeys <hex[,hex...]> [--operator-pubkeys <hex[,hex...]>] [--state-dir <path>]"
+    echo "  --state-dir  Where the database and root credential live. Defaults to this checkout."
 }
 
 while [[ "$#" -gt 0 ]]; do
@@ -17,6 +19,7 @@ while [[ "$#" -gt 0 ]]; do
         --domain) DOMAIN="${2:-}"; shift 2 ;;
         --allowed-pubkeys) ALLOWED_PUBKEYS="${2:-}"; shift 2 ;;
         --operator-pubkeys) OPERATOR_PUBKEYS="${2:-}"; shift 2 ;;
+        --state-dir) STATE_DIR_ARG="${2:-}"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "Unknown argument: $1"; usage; exit 1 ;;
     esac
@@ -46,19 +49,33 @@ if [[ -e .env ]]; then
     echo "Error: .env already exists; refusing to overwrite it"
     exit 1
 fi
-if [[ ! -f master.key ]]; then
-    bash scripts/generate_key.sh
+# Must match ${KEYCAST_STATE_DIR:-.} in the Compose files.
+if [[ -z "$STATE_DIR_ARG" ]]; then
+    STATE_DIR="$ROOT_DIR"
+elif [[ "$STATE_DIR_ARG" = /* ]]; then
+    STATE_DIR="$STATE_DIR_ARG"
+else
+    STATE_DIR="$ROOT_DIR/$STATE_DIR_ARG"
 fi
-mkdir -p database
-chmod 700 database
-chmod 600 master.key
-if ! chown -R "$KEYCAST_UID:$KEYCAST_GID" database master.key 2>/dev/null; then
+DATABASE_DIR="$STATE_DIR/database"
+ROOT_KEY="$STATE_DIR/master.key"
+mkdir -p "$STATE_DIR"
+if [[ ! -f "$ROOT_KEY" ]]; then
+    KEYCAST_ROOT_KEY_PATH="$ROOT_KEY" bash scripts/generate_key.sh
+fi
+mkdir -p "$DATABASE_DIR"
+chmod 700 "$DATABASE_DIR"
+chmod 600 "$ROOT_KEY"
+if ! chown -R "$KEYCAST_UID:$KEYCAST_GID" "$DATABASE_DIR" "$ROOT_KEY" 2>/dev/null; then
     echo "Warning: could not set container ownership."
-    echo "Run: sudo chown -R $KEYCAST_UID:$KEYCAST_GID database master.key"
+    echo "Run: sudo chown -R $KEYCAST_UID:$KEYCAST_GID $DATABASE_DIR $ROOT_KEY"
 fi
 
 {
     echo "DOMAIN=$DOMAIN"
+    if [[ "$STATE_DIR" != "$ROOT_DIR" ]]; then
+        echo "KEYCAST_STATE_DIR=$STATE_DIR"
+    fi
     echo "ALLOWED_PUBKEYS=$ALLOWED_PUBKEYS"
     echo "KEYCAST_OPERATOR_PUBKEYS=$OPERATOR_PUBKEYS"
     echo "KEYCAST_API_IMAGE=ghcr.io/marmot-protocol/keycast-api"

--- a/scripts/management-smoke.mjs
+++ b/scripts/management-smoke.mjs
@@ -30,7 +30,11 @@ async function request(method,path,data,legacy=false) {
  const response=await http(base+path,{method,headers:{authorization:'Nostr '+Buffer.from(JSON.stringify(event)).toString('base64'),'content-type':'application/json'},body:write&&body?body:undefined});
  if(write&&!legacy&&response.ok) {
   const encrypted=await response.json();assert.ok(encrypted.encrypted_response);assert.ok(!JSON.stringify(encrypted).includes('bunker://'));
-  const reply=JSON.parse(nip44.decrypt(encrypted.encrypted_response,nip44.utils.getConversationKey(responseKey,encrypted.public_key)));
+  // The signer must reply from the stable identity /config publishes, so NIP-44
+  // authenticates the sender. Decrypt with the published key, never the returned one.
+  assert.match(config.management_reply_public_key,/^[0-9a-f]{64}$/);
+  assert.equal(encrypted.public_key,config.management_reply_public_key);
+  const reply=JSON.parse(nip44.decrypt(encrypted.encrypted_response,nip44.utils.getConversationKey(responseKey,config.management_reply_public_key)));
   return {status:reply.status,body:reply.body?JSON.parse(reply.body):null};
  }
  return {status:response.status,body:await response.json().catch(()=>null)};
@@ -52,5 +56,14 @@ const legacyResult=await new Promise((resolve,reject)=>{
  socket.on('connect',()=>socket.end(JSON.stringify({operation:'create_grant',team_id:team.body.team.id,actor_public_key:pubkey,stored_key_id:imported.body.id,policy_id:policy.body.id,name:'Forged authority',expires_at:null,invitation_expires_at:Math.floor(Date.now()/1000)+300})));
 });
 assert.equal(legacyResult.result,'error');assert.equal(legacyResult.code,'invalid_request');
+// The reply identity is stable across requests, not fresh per reply.
+const firstConfig=await http(`${base}/config?pubkey=${pubkey}`).then(r=>r.json());
+const secondConfig=await http(`${base}/config?pubkey=${pubkey}`).then(r=>r.json());
+assert.equal(firstConfig.management_reply_public_key,secondConfig.management_reply_public_key);
+// An approval whose description would carry private material is refused.
+assert.equal((await request('POST',`/teams/${team.body.team.id}/keys`,{name:'nsec1pasted',secret_key:Buffer.from(key).toString('hex')})).status,400);
+// A team that has issued a grant must still be deletable.
+assert.equal((await request('DELETE',`/teams/${team.body.team.id}`)).status,204);
+assert.equal((await request('GET',`/teams/${team.body.team.id}`)).status,403);
 key.fill(0);responseKey.fill(0);
-console.log('PASS: read-only API/signer/web; signed management; legacy write rejection; browser key import; encrypted invitation creation');
+console.log('PASS: read-only API/signer/web; signed management; pinned reply identity; legacy write rejection; browser key import; encrypted invitation creation; approval content guard; team delete with grants');

--- a/scripts/upgrade_preflight.sh
+++ b/scripts/upgrade_preflight.sh
@@ -62,6 +62,29 @@ for directory in database; do
     [[ -d "$ROOT_DIR/$directory" ]] && ok "$directory directory exists" || fail "$directory directory is missing"
 done
 
+if [[ -f "$ROOT_DIR/database/keycast.db" ]]; then
+    warn "database/keycast.db is legacy and will be ignored by v2"
+fi
+# Read-only, and before the ownership repair below: opening a WAL database
+# read-write creates -wal/-shm sidecars, and an interrupted run would leave them
+# owned by root where the container user (10001) could not open the database.
+if [[ -f "$ROOT_DIR/database/keycast-v2.db" ]] && command -v sqlite3 >/dev/null 2>&1; then
+    db_uri="file:$ROOT_DIR/database/keycast-v2.db?mode=ro"
+    integrity="$(sqlite3 -readonly "$db_uri" 'PRAGMA quick_check;' 2>/dev/null || true)"
+    [[ "$integrity" == "ok" ]] && ok "v2 database quick_check passed" || fail "v2 database quick_check failed"
+    schema="$(sqlite3 -readonly "$db_uri" 'PRAGMA user_version;' 2>/dev/null || true)"
+    [[ "$schema" == "2" ]] && ok "v2 schema version is 2" || fail "unexpected v2 schema version: $schema"
+    for sidecar in wal shm; do
+        if [[ -e "$ROOT_DIR/database/keycast-v2.db-$sidecar" ]] \
+            && [[ "$(stat -f '%u' "$ROOT_DIR/database/keycast-v2.db-$sidecar" 2>/dev/null \
+                || stat -c '%u' "$ROOT_DIR/database/keycast-v2.db-$sidecar" 2>/dev/null)" != "$KEYCAST_UID" ]]; then
+            warn "database/keycast-v2.db-$sidecar is not owned by $KEYCAST_UID; --fix-permissions will repair it"
+        fi
+    done
+else
+    warn "no v2 database yet; the signer will create it on first start"
+fi
+
 if [[ "$FIX_PERMISSIONS" == true && -f "$ROOT_DIR/master.key" ]]; then
     chmod 700 "$ROOT_DIR/database"
     chmod 600 "$ROOT_DIR/master.key"
@@ -74,27 +97,43 @@ else
     warn "permission repair not requested; use --fix-permissions before first container start"
 fi
 
-if [[ -f "$ROOT_DIR/database/keycast.db" ]]; then
-    warn "database/keycast.db is legacy and will be ignored by v2"
-fi
-if [[ -f "$ROOT_DIR/database/keycast-v2.db" ]] && command -v sqlite3 >/dev/null 2>&1; then
-    integrity="$(sqlite3 "$ROOT_DIR/database/keycast-v2.db" 'PRAGMA quick_check;' 2>/dev/null || true)"
-    [[ "$integrity" == "ok" ]] && ok "v2 database quick_check passed" || fail "v2 database quick_check failed"
-    schema="$(sqlite3 "$ROOT_DIR/database/keycast-v2.db" 'PRAGMA user_version;' 2>/dev/null || true)"
-    [[ "$schema" == "2" ]] && ok "v2 schema version is 2" || fail "unexpected v2 schema version: $schema"
-else
-    warn "no v2 database yet; the signer will create it on first start"
-fi
-
 if [[ -z "$KEYCAST_OPERATOR_PUBKEYS" ]]; then
     fail "KEYCAST_OPERATOR_PUBKEYS is required for global relay management"
 fi
+ATTESTATION_REPO="${KEYCAST_ATTESTATION_REPO:-marmot-protocol/keycast}"
 for component in API SIGNER WEB; do
     digest_name="KEYCAST_${component}_DIGEST"
     digest_value="${!digest_name:-$(env_value "$digest_name")}"
-    [[ "$digest_value" =~ ^sha256:[0-9a-f]{64}$ ]] || fail "$digest_name must be a reviewed sha256 image digest"
+    if [[ ! "$digest_value" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+        fail "$digest_name must be a sha256 image digest"
+        continue
+    fi
+    image_name="KEYCAST_${component}_IMAGE"
+    image_value="${!image_name:-$(env_value "$image_name")}"
+    image_value="${image_value:-ghcr.io/marmot-protocol/keycast-$(echo "$component" | tr 'A-Z' 'a-z')}"
+    # A digest only pins what you already trust. Verify it was produced by this
+    # repository's workflow instead of trusting a mutable tag it was read from.
+    if command -v gh >/dev/null 2>&1; then
+        if gh attestation verify "oci://${image_value}@${digest_value}" \
+            --repo "$ATTESTATION_REPO" >/dev/null 2>&1; then
+            ok "$component image digest has verified build provenance"
+        else
+            fail "$component image digest has no verifiable provenance from $ATTESTATION_REPO"
+        fi
+    else
+        warn "gh is not installed; install it to verify $component build provenance with: gh attestation verify oci://${image_value}@${digest_value} --repo $ATTESTATION_REPO"
+    fi
 done
 if command -v docker >/dev/null 2>&1; then
+    if docker network inspect keycast >/dev/null 2>&1; then
+        if [[ "$(docker network inspect keycast --format '{{.Internal}}' 2>/dev/null)" == "true" ]]; then
+            ok "the keycast network is internal"
+        else
+            warn "the keycast network is not internal; api and web can reach the Internet. Recreate it with: docker network rm keycast && docker network create --internal keycast"
+        fi
+    else
+        fail "the external 'keycast' network is missing; create it with: docker network create --internal keycast"
+    fi
     if KEYCAST_OPERATOR_PUBKEYS="$KEYCAST_OPERATOR_PUBKEYS" DOMAIN="$DOMAIN" ALLOWED_PUBKEYS="$ALLOWED_PUBKEYS" \
         docker compose -f "$ROOT_DIR/docker-compose.prod.yml" config --quiet; then
         ok "Docker Compose configuration renders"

--- a/scripts/upgrade_preflight.sh
+++ b/scripts/upgrade_preflight.sh
@@ -117,7 +117,9 @@ else
     warn "no v2 database yet; the signer will create it on first start"
 fi
 
-if [[ "$FIX_PERMISSIONS" == true && -f "$ROOT_KEY" ]]; then
+# Require both paths: without the directory guard, chmod fails under `set -e`
+# and the script exits before printing the collected failure summary.
+if [[ "$FIX_PERMISSIONS" == true && -f "$ROOT_KEY" && -d "$DATABASE_DIR" ]]; then
     chmod 700 "$DATABASE_DIR"
     chmod 600 "$ROOT_KEY"
     if chown -R "$KEYCAST_UID:$KEYCAST_GID" "$DATABASE_DIR" "$ROOT_KEY" 2>/dev/null; then
@@ -125,6 +127,8 @@ if [[ "$FIX_PERMISSIONS" == true && -f "$ROOT_KEY" ]]; then
     else
         fail "could not chown runtime files; retry with sudo"
     fi
+elif [[ "$FIX_PERMISSIONS" == true ]]; then
+    fail "cannot repair permissions until $ROOT_KEY and $DATABASE_DIR both exist"
 else
     warn "permission repair not requested; use --fix-permissions before first container start"
 fi

--- a/scripts/upgrade_preflight.sh
+++ b/scripts/upgrade_preflight.sh
@@ -28,6 +28,18 @@ env_value() {
 ALLOWED_PUBKEYS="${ALLOWED_PUBKEYS:-$(env_value ALLOWED_PUBKEYS)}"
 DOMAIN="${DOMAIN:-$(env_value DOMAIN)}"
 KEYCAST_OPERATOR_PUBKEYS="${KEYCAST_OPERATOR_PUBKEYS:-$(env_value KEYCAST_OPERATOR_PUBKEYS)}"
+# Must resolve exactly like ${KEYCAST_STATE_DIR:-.} in the Compose files, or this
+# would check and repair a stale copy while the containers mount another one.
+KEYCAST_STATE_DIR="${KEYCAST_STATE_DIR:-$(env_value KEYCAST_STATE_DIR)}"
+if [[ -z "$KEYCAST_STATE_DIR" ]]; then
+    STATE_DIR="$ROOT_DIR"
+elif [[ "$KEYCAST_STATE_DIR" = /* ]]; then
+    STATE_DIR="$KEYCAST_STATE_DIR"
+else
+    STATE_DIR="$ROOT_DIR/$KEYCAST_STATE_DIR"
+fi
+DATABASE_DIR="$STATE_DIR/database"
+ROOT_KEY="$STATE_DIR/master.key"
 KEYCAST_UID=10001
 KEYCAST_GID=10001
 failures=0
@@ -49,46 +61,66 @@ for pubkey_name in ALLOWED_PUBKEYS KEYCAST_OPERATOR_PUBKEYS; do
     fi
 done
 
-if [[ -f "$ROOT_DIR/master.key" ]]; then
-    key_value="$(tr -d '\r\n' < "$ROOT_DIR/master.key")"
-    [[ "$key_value" =~ ^[0-9a-fA-F]{64}$ || "$key_value" =~ ^[A-Za-z0-9+/]{43}=$ ]] \
-        && ok "master.key encodes exactly 32 bytes" \
-        || fail "master.key must contain one base64 or hex encoded 32-byte key"
+if [[ "$STATE_DIR" != "$ROOT_DIR" ]]; then
+    ok "state directory is $STATE_DIR"
+fi
+if [[ -f "$ROOT_KEY" ]]; then
+    key_value="$(tr -d '\r\n' < "$ROOT_KEY")"
+    if [[ "$key_value" =~ ^[0-9a-fA-F]{64}$ || "$key_value" =~ ^[A-Za-z0-9+/]{43}=$ ]]; then
+        ok "master.key encodes exactly 32 bytes"
+    else
+        fail "master.key must contain one base64 or hex encoded 32-byte key"
+    fi
 else
-    fail "master.key is missing"
+    fail "$ROOT_KEY is missing"
 fi
 
-for directory in database; do
-    [[ -d "$ROOT_DIR/$directory" ]] && ok "$directory directory exists" || fail "$directory directory is missing"
-done
+if [[ -d "$DATABASE_DIR" ]]; then
+    ok "database directory exists"
+else
+    fail "$DATABASE_DIR is missing"
+fi
 
-if [[ -f "$ROOT_DIR/database/keycast.db" ]]; then
-    warn "database/keycast.db is legacy and will be ignored by v2"
+if [[ -f "$DATABASE_DIR/keycast.db" ]]; then
+    warn "keycast.db is legacy and will be ignored by v2"
 fi
 # Read-only, and before the ownership repair below: opening a WAL database
 # read-write creates -wal/-shm sidecars, and an interrupted run would leave them
 # owned by root where the container user (10001) could not open the database.
-if [[ -f "$ROOT_DIR/database/keycast-v2.db" ]] && command -v sqlite3 >/dev/null 2>&1; then
-    db_uri="file:$ROOT_DIR/database/keycast-v2.db?mode=ro"
-    integrity="$(sqlite3 -readonly "$db_uri" 'PRAGMA quick_check;' 2>/dev/null || true)"
-    [[ "$integrity" == "ok" ]] && ok "v2 database quick_check passed" || fail "v2 database quick_check failed"
-    schema="$(sqlite3 -readonly "$db_uri" 'PRAGMA user_version;' 2>/dev/null || true)"
-    [[ "$schema" == "2" ]] && ok "v2 schema version is 2" || fail "unexpected v2 schema version: $schema"
+# GNU form first: on Linux `stat -f` means --file-system, which would print
+# filesystem status to stdout before failing and corrupt the captured value.
+file_owner() {
+    stat -c '%u' "$1" 2>/dev/null || stat -f '%u' "$1" 2>/dev/null || true
+}
+if [[ -f "$DATABASE_DIR/keycast-v2.db" ]] && command -v sqlite3 >/dev/null 2>&1; then
+    # `-readonly` is the read-only guarantee. A `file:` URI would be read as a
+    # literal path wherever URI filenames are not enabled.
+    database="$DATABASE_DIR/keycast-v2.db"
+    integrity="$(sqlite3 -readonly "$database" 'PRAGMA quick_check;' 2>/dev/null || true)"
+    if [[ "$integrity" == "ok" ]]; then
+        ok "v2 database quick_check passed"
+    else
+        fail "v2 database quick_check failed"
+    fi
+    schema="$(sqlite3 -readonly "$database" 'PRAGMA user_version;' 2>/dev/null || true)"
+    if [[ "$schema" == "2" ]]; then
+        ok "v2 schema version is 2"
+    else
+        fail "unexpected v2 schema version: $schema"
+    fi
     for sidecar in wal shm; do
-        if [[ -e "$ROOT_DIR/database/keycast-v2.db-$sidecar" ]] \
-            && [[ "$(stat -f '%u' "$ROOT_DIR/database/keycast-v2.db-$sidecar" 2>/dev/null \
-                || stat -c '%u' "$ROOT_DIR/database/keycast-v2.db-$sidecar" 2>/dev/null)" != "$KEYCAST_UID" ]]; then
-            warn "database/keycast-v2.db-$sidecar is not owned by $KEYCAST_UID; --fix-permissions will repair it"
+        if [[ -e "$database-$sidecar" && "$(file_owner "$database-$sidecar")" != "$KEYCAST_UID" ]]; then
+            warn "keycast-v2.db-$sidecar is not owned by $KEYCAST_UID; --fix-permissions will repair it"
         fi
     done
 else
     warn "no v2 database yet; the signer will create it on first start"
 fi
 
-if [[ "$FIX_PERMISSIONS" == true && -f "$ROOT_DIR/master.key" ]]; then
-    chmod 700 "$ROOT_DIR/database"
-    chmod 600 "$ROOT_DIR/master.key"
-    if chown -R "$KEYCAST_UID:$KEYCAST_GID" "$ROOT_DIR/database" "$ROOT_DIR/master.key" 2>/dev/null; then
+if [[ "$FIX_PERMISSIONS" == true && -f "$ROOT_KEY" ]]; then
+    chmod 700 "$DATABASE_DIR"
+    chmod 600 "$ROOT_KEY"
+    if chown -R "$KEYCAST_UID:$KEYCAST_GID" "$DATABASE_DIR" "$ROOT_KEY" 2>/dev/null; then
         ok "container ownership and permissions updated"
     else
         fail "could not chown runtime files; retry with sudo"
@@ -114,11 +146,13 @@ for component in API SIGNER WEB; do
     # A digest only pins what you already trust. Verify it was produced by this
     # repository's workflow instead of trusting a mutable tag it was read from.
     if command -v gh >/dev/null 2>&1; then
-        if gh attestation verify "oci://${image_value}@${digest_value}" \
-            --repo "$ATTESTATION_REPO" >/dev/null 2>&1; then
+        # Always blocking. Carry the diagnostic so an authentication or network
+        # failure is not reported as if the image simply had no provenance.
+        if verify_output="$(gh attestation verify "oci://${image_value}@${digest_value}" \
+            --repo "$ATTESTATION_REPO" 2>&1)"; then
             ok "$component image digest has verified build provenance"
         else
-            fail "$component image digest has no verifiable provenance from $ATTESTATION_REPO"
+            fail "$component provenance verification failed against $ATTESTATION_REPO: $(printf '%s' "$verify_output" | tr '\n' ' ' | cut -c1-300)"
         fi
     else
         warn "gh is not installed; install it to verify $component build provenance with: gh attestation verify oci://${image_value}@${digest_value} --repo $ATTESTATION_REPO"

--- a/signer/src/admission.rs
+++ b/signer/src/admission.rs
@@ -85,20 +85,47 @@ struct State {
     rate: Counts,
     running: Counts,
 }
+/// Global, per-client and per-grant ceilings for one admission lane.
+#[derive(Clone, Copy)]
+pub(crate) struct Limits {
+    running: (usize, usize, usize),
+    rate: (usize, usize, usize),
+}
+impl Limits {
+    /// Clients holding a live session on the target grant.
+    pub const ESTABLISHED: Self = Self {
+        running: (32, 2, 8),
+        rate: (128, 16, 32),
+    };
+    /// Everything else, including `connect` and forged traffic. A grant's
+    /// remote-signer key is public, so anyone can publish events addressed to it;
+    /// keeping that traffic in its own lane means a flood cannot consume the
+    /// budget that established sessions draw from.
+    pub const NEWCOMER: Self = Self {
+        running: (8, 2, 4),
+        rate: (32, 4, 8),
+    };
+}
+
 #[derive(Clone)]
 pub(crate) struct Admission {
     start: Instant,
+    limits: Limits,
     state: Arc<Mutex<State>>,
 }
 impl Default for Admission {
     fn default() -> Self {
-        Self {
-            start: Instant::now(),
-            state: Arc::default(),
-        }
+        Self::new(Limits::ESTABLISHED)
     }
 }
 impl Admission {
+    pub fn new(limits: Limits) -> Self {
+        Self {
+            start: Instant::now(),
+            limits,
+            state: Arc::default(),
+        }
+    }
     pub fn try_admit(&self, client: &str, grant: &str) -> Option<Ticket> {
         self.try_admit_reason(client, grant).ok()
     }
@@ -119,7 +146,7 @@ impl Admission {
         for (counts, limits, reasons) in [
             (
                 &state.running,
-                (32, 2, 8),
+                self.limits.running,
                 [
                     "admission_running_global",
                     "admission_running_client",
@@ -128,7 +155,7 @@ impl Admission {
             ),
             (
                 &state.rate,
-                (128, 16, 32),
+                self.limits.rate,
                 [
                     "admission_rate_global",
                     "admission_rate_client",
@@ -270,6 +297,32 @@ mod tests {
         assert!(state.running.clients.is_empty());
         assert!(state.running.grants.is_empty());
         assert_eq!(state.rate.total, 3);
+    }
+
+    #[test]
+    fn a_newcomer_flood_cannot_starve_established_sessions() {
+        let established = Admission::new(Limits::ESTABLISHED);
+        let newcomers = Admission::new(Limits::NEWCOMER);
+
+        // Forged events from rotating keys fill only the newcomer lane.
+        let mut admitted = 0;
+        for n in 0..512 {
+            if newcomers
+                .try_admit_at(&format!("forged-{n}"), "victim-grant", 0)
+                .is_some()
+            {
+                admitted += 1;
+            }
+        }
+        assert_eq!(admitted, Limits::NEWCOMER.running.0);
+        assert!(newcomers
+            .try_admit_at("another", "victim-grant", 0)
+            .is_none());
+
+        // The established lane is untouched and still serves the real client.
+        assert!(established
+            .try_admit_at("live-client", "victim-grant", 0)
+            .is_some());
     }
 
     #[test]

--- a/signer/src/admission.rs
+++ b/signer/src/admission.rs
@@ -304,20 +304,27 @@ mod tests {
         let established = Admission::new(Limits::ESTABLISHED);
         let newcomers = Admission::new(Limits::NEWCOMER);
 
-        // Forged events from rotating keys fill only the newcomer lane.
-        let mut admitted = 0;
-        for n in 0..512 {
-            if newcomers
-                .try_admit_at(&format!("forged-{n}"), "victim-grant", 0)
-                .is_some()
-            {
-                admitted += 1;
-            }
-        }
-        assert_eq!(admitted, Limits::NEWCOMER.running.0);
+        // Hold the tickets so concurrency actually accumulates. A dropped ticket
+        // returns its slot at once, which would leave the rate limit as the only
+        // constraint under test and make either constant look load-bearing.
+        let held: Vec<_> = (0..512)
+            .filter_map(|n| newcomers.try_admit_at(&format!("forged-{n}"), "victim-grant", 0))
+            .collect();
+        assert_eq!(held.len(), Limits::NEWCOMER.running.2);
         assert!(newcomers
             .try_admit_at("another", "victim-grant", 0)
             .is_none());
+
+        // Completed work still spends the per-grant rate budget for the window.
+        drop(held);
+        let admitted = (0..512)
+            .filter(|n| {
+                newcomers
+                    .try_admit_at(&format!("burst-{n}"), "other-grant", 1)
+                    .is_some()
+            })
+            .count();
+        assert_eq!(admitted, Limits::NEWCOMER.rate.2);
 
         // The established lane is untouched and still serves the real client.
         assert!(established

--- a/signer/src/control.rs
+++ b/signer/src/control.rs
@@ -138,7 +138,7 @@ async fn handle_connection(
                     } else {
                         builder
                     };
-                    match builder.body(axum::body::Body::from(body)) {
+                    match builder.body(axum::body::Body::from(body.expose().to_owned())) {
                         Ok(request) => {
                             let response =
                                 router.oneshot(request).await.expect("infallible router");
@@ -187,7 +187,12 @@ pub(crate) async fn dispatch_lifecycle(
             secret_key,
         } => state
             .store
-            .seal_stored_key(team_id, &actor_public_key, name, Zeroizing::new(secret_key))
+            .seal_stored_key(
+                team_id,
+                &actor_public_key,
+                name,
+                secret_key.into_zeroizing(),
+            )
             .await
             .map(|key| ControlResponse::StoredKey { key }),
         LifecycleRequest::CreateGrant {
@@ -319,7 +324,7 @@ mod connection_tests {
                 method: "GET".into(),
                 path: endpoint.into(),
                 authorization: None,
-                body: String::new(),
+                body: keycast_core::v2::secret::Secret::new(String::new()),
             };
             stream
                 .write_all(&serde_json::to_vec(&request).unwrap())

--- a/signer/src/maintenance.rs
+++ b/signer/src/maintenance.rs
@@ -159,6 +159,14 @@ pub async fn command(args: &[String], root: &Path) -> Result<()> {
         }
         "backup" if args.len() == 3 => {
             let backup_cipher = EnvelopeCipher::from_file(Path::new(&args[1]))?;
+            // The manifest carries the root credential, so the archive is only as
+            // separate as its key. Reusing the root removes that separation.
+            if backup_cipher.key_id() == store.cipher.key_id() {
+                return Err(
+                    "backup key must differ from the root credential; generate one with generate-key"
+                        .into(),
+                );
+            }
             let root_path = keycast_core::v2::envelope::credential_path()
                 .ok_or("root credential path required")?;
             let private_root = Zeroizing::new(std::fs::read_to_string(root_path)?);

--- a/signer/src/management/api/http/hardening_tests.rs
+++ b/signer/src/management/api/http/hardening_tests.rs
@@ -519,3 +519,196 @@ async fn discovery_policy_requires_operator_and_signed_approval() {
     assert_eq!(route_request(&app,&pool,&operator,"PUT","/relay-discovery",r#"{"auto_activate":true,"allow_private":true}"#).await.status,422);
     env::remove_var("ALLOWED_PUBKEYS"); env::remove_var("KEYCAST_OPERATOR_PUBKEYS");
 }
+
+#[tokio::test]
+async fn team_delete_removes_grants_that_would_otherwise_block_the_cascade() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let pool = setup_route_test_db().await;
+    let admin = Keys::generate();
+    env::set_var("ALLOWED_PUBKEYS", admin.public_key().to_hex());
+    let app = crate::management::api::http::routes::routes(state(pool.clone()));
+
+    let team: i64 = query_scalar("INSERT INTO teams(name) VALUES('Doomed') RETURNING id")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    member_row(&pool, team, &admin, "admin").await;
+    let stored_key: i64 = query_scalar(
+        "INSERT INTO stored_keys(team_id,name,public_key,secret_envelope,envelope_version,key_encryption_key_id) VALUES(?,'k',?,x'01',1,'kid') RETURNING id")
+        .bind(team)
+        .bind(Keys::generate().public_key().to_hex())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let policy: i64 = query_scalar(
+        "INSERT INTO policies(team_id,name,document) VALUES(?,'p','{\"version\":1}') RETURNING id",
+    )
+    .bind(team)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    // A revoked grant is a tombstone, so it blocks the cascade exactly like a live one.
+    for (name, revoked) in [("live", false), ("revoked", true)] {
+        let grant: i64 = query_scalar(
+            "INSERT INTO grants(team_id,stored_key_id,policy_id,name,remote_signer_public_key,remote_signer_secret_envelope,envelope_version,key_encryption_key_id) VALUES(?,?,?,?,?,x'01',1,'kid') RETURNING id")
+            .bind(team).bind(stored_key).bind(policy).bind(name)
+            .bind(Keys::generate().public_key().to_hex())
+            .fetch_one(&pool).await.unwrap();
+        let invitation: i64 = query_scalar(
+            "INSERT INTO invitations(grant_id,secret_hash,expires_at) VALUES(?,randomblob(32),unixepoch()+3600) RETURNING id")
+            .bind(grant).fetch_one(&pool).await.unwrap();
+        query("INSERT INTO sessions(grant_id,invitation_id,client_public_key) VALUES(?,?,?)")
+            .bind(grant)
+            .bind(invitation)
+            .bind(Keys::generate().public_key().to_hex())
+            .execute(&pool)
+            .await
+            .unwrap();
+        if revoked {
+            query("UPDATE grants SET revoked_at=unixepoch() WHERE id=?")
+                .bind(grant)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+    }
+
+    let path = format!("/teams/{team}");
+    let reply = route_request(&app, &pool, &admin, "DELETE", &path, "").await;
+    assert_eq!(reply.status, StatusCode::NO_CONTENT.as_u16());
+    let remaining: (i64, i64, i64, i64, i64, i64, i64) = query_as(
+        "SELECT (SELECT count(*) FROM teams),(SELECT count(*) FROM grants),
+                (SELECT count(*) FROM sessions),(SELECT count(*) FROM invitations),
+                (SELECT count(*) FROM stored_keys),(SELECT count(*) FROM policies),
+                (SELECT count(*) FROM team_members)",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(remaining, (0, 0, 0, 0, 0, 0, 0));
+    // The audit trail outlives the team, with its links cleared.
+    let recorded: i64 =
+        query_scalar("SELECT count(*) FROM audit_events WHERE action='team.delete'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(recorded, 1);
+    env::remove_var("ALLOWED_PUBKEYS");
+}
+
+#[tokio::test]
+async fn approval_content_carrying_private_material_is_refused() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let pool = setup_route_test_db().await;
+    let admin = Keys::generate();
+    env::set_var("ALLOWED_PUBKEYS", admin.public_key().to_hex());
+    let app = crate::management::api::http::routes::routes(state(pool.clone()));
+    let team: i64 = query_scalar("INSERT INTO teams(name) VALUES('Keys') RETURNING id")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    member_row(&pool, team, &admin, "admin").await;
+    let endpoint = format!("/teams/{team}/keys");
+    let imported = Keys::generate();
+
+    // An operator pasting a private key into the name field would otherwise ship it
+    // to the external signer inside the approval event's content.
+    let pasted = format!(
+        r#"{{"name":"{}","secret_key":"{}"}}"#,
+        imported.secret_key().to_bech32().unwrap(),
+        imported.secret_key().to_secret_hex()
+    );
+    let reply = route_request(&app, &pool, &admin, "POST", &endpoint, &pasted).await;
+    assert_eq!(reply.status, StatusCode::BAD_REQUEST.as_u16());
+    assert!(!reply.body.contains("nsec1"));
+
+    // A named import still works, and its approval never carries the key.
+    let clean = format!(
+        r#"{{"name":"Personal identity","secret_key":"{}"}}"#,
+        imported.secret_key().to_secret_hex()
+    );
+    let reply = route_request(&app, &pool, &admin, "POST", &endpoint, &clean).await;
+    assert_eq!(reply.status, StatusCode::CREATED.as_u16());
+    let stored: i64 = query_scalar("SELECT count(*) FROM stored_keys")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(stored, 1);
+    env::remove_var("ALLOWED_PUBKEYS");
+}
+
+#[tokio::test]
+async fn management_replies_come_from_the_published_stable_identity() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let pool = setup_route_test_db().await;
+    let admin = Keys::generate();
+    env::set_var("ALLOWED_PUBKEYS", admin.public_key().to_hex());
+    let app = crate::management::api::http::routes::routes(state(pool.clone()));
+
+    // The browser learns the reply identity from /config and pins it.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/config?pubkey={}", admin.public_key().to_hex()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let config: serde_json::Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), MAX_AUTH_BODY_BYTES)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let published = config["management_reply_public_key"]
+        .as_str()
+        .expect("published reply identity")
+        .to_owned();
+    let pinned = PublicKey::from_hex(&published).unwrap();
+
+    // Every write reply must come from that identity, not a per-reply ephemeral key.
+    let mut senders = BTreeSet::new();
+    for name in ["First", "Second"] {
+        let body = format!(r#"{{"name":"{name}"}}"#);
+        let revision: i64 = query_scalar("SELECT authority_revision FROM instance_settings")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let response = app
+            .clone()
+            .oneshot(signed_request(&admin, "POST", "/teams", &body, revision))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let envelope: keycast_core::v2::control::EncryptedReply = serde_json::from_slice(
+            &to_bytes(response.into_body(), MAX_AUTH_BODY_BYTES)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        senders.insert(envelope.public_key.clone());
+        let plain = nostr::nips::nip44::decrypt(
+            admin.secret_key(),
+            &pinned,
+            &envelope.encrypted_response,
+        )
+        .expect("reply authenticates under the pinned identity");
+        let reply: keycast_core::v2::control::HttpReply = serde_json::from_str(&plain).unwrap();
+        assert_eq!(reply.status, StatusCode::CREATED.as_u16());
+    }
+    assert_eq!(senders, BTreeSet::from([published]));
+
+    // A reply forged by anyone else, including the API, fails to authenticate.
+    let forged = nostr::nips::nip44::encrypt(
+        Keys::generate().secret_key(),
+        &admin.public_key(),
+        r#"{"status":201,"body":"forged"}"#,
+        nostr::nips::nip44::Version::default(),
+    )
+    .unwrap();
+    assert!(nostr::nips::nip44::decrypt(admin.secret_key(), &pinned, &forged).is_err());
+    env::remove_var("ALLOWED_PUBKEYS");
+}

--- a/signer/src/management/api/http/mod.rs
+++ b/signer/src/management/api/http/mod.rs
@@ -32,6 +32,9 @@ pub struct PublicConfig {
     pub pubkey_allowed: bool,
     pub instance_id: String,
     pub authority_revision: i64,
+    /// Stable identity that encrypts management replies. A browser pins this and
+    /// refuses a reply from any other sender, so the API cannot forge outcomes.
+    pub management_reply_public_key: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
@@ -118,14 +121,25 @@ pub async fn auth_middleware(
         return next.run(request).await;
     }
     let body_text = std::str::from_utf8(&body_bytes).unwrap_or("");
-    if keycast_core::v2::management::description(
+    let described = keycast_core::v2::management::description(
         request.method().as_str(),
         request.uri().path(),
         body_text,
-    )
-    .as_deref()
-        != Some(&event.content)
+    );
+    // Fail closed before matching. An approval event is displayed by, stored in,
+    // and for NIP-46 signers transported to an external key store, so private
+    // material must never reach one even if a route or the frontend regresses.
+    if described
+        .as_deref()
+        .is_some_and(keycast_core::v2::management::contains_secret_marker)
+        || keycast_core::v2::management::contains_secret_marker(&event.content)
     {
+        return response_with_status(
+            StatusCode::BAD_REQUEST,
+            "Approval content must not contain private key material",
+        );
+    }
+    if described.as_deref() != Some(event.content.as_str()) {
         return response_with_status(
             StatusCode::UNAUTHORIZED,
             "Approval contents do not match the command",
@@ -182,9 +196,17 @@ pub async fn auth_middleware(
         status,
         body: String::from_utf8_lossy(&bytes).into_owned(),
     };
-    let keys = Keys::generate();
+    // A fresh key per reply left NIP-44 with nothing to authenticate: anyone
+    // holding the public `response` pubkey could forge a reply. The stable
+    // root-derived identity makes NIP-44 authenticate the sender.
+    let Ok(reply_keys) = state.signer.runtime.store.cipher.management_reply_keys() else {
+        return response_with_status(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Management reply identity unavailable",
+        );
+    };
     let encrypted = nostr::nips::nip44::encrypt(
-        keys.secret_key(),
+        reply_keys.secret_key(),
         &recipient,
         serde_json::to_string(&reply).unwrap(),
         nostr::nips::nip44::Version::default(),
@@ -193,7 +215,7 @@ pub async fn auth_middleware(
     match encrypted {
         Ok(encrypted_response) => Json(keycast_core::v2::control::EncryptedReply {
             encrypted_response,
-            public_key: keys.public_key().to_hex(),
+            public_key: reply_keys.public_key().to_hex(),
         })
         .into_response(),
         Err(_) => response_with_status(
@@ -213,10 +235,18 @@ pub async fn public_config(
     .fetch_one(&state.db)
     .await
     .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    let management_reply_public_key = state
+        .signer
+        .runtime
+        .store
+        .cipher
+        .management_reply_public_key()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
     Ok(Json(PublicConfig {
         pubkey_allowed: is_allowed_pubkey_hex(&query.pubkey),
         instance_id,
         authority_revision,
+        management_reply_public_key,
     }))
 }
 
@@ -470,8 +500,9 @@ mod tests {
 
     use super::*;
     use axum::http::Method;
-    use sqlx::{query::query, query_scalar::query_scalar, raw_sql::raw_sql};
+    use sqlx::{query::query, query_as::query_as, query_scalar::query_scalar, raw_sql::raw_sql};
     use sqlx_sqlite::{SqlitePool, SqlitePoolOptions};
+    use std::collections::BTreeSet;
 
     use std::sync::Mutex;
     use tower::ServiceExt;

--- a/signer/src/management/api/http/teams.rs
+++ b/signer/src/management/api/http/teams.rs
@@ -109,8 +109,18 @@ pub async fn delete_team(
 ) -> ApiResult<StatusCode> {
     let actor = event.pubkey.to_hex();
     require_admin(&state.db, id, &actor).await?;
-    let mut transaction = state.db.begin().await?;
+    let mut transaction = state.db.begin_with("BEGIN IMMEDIATE").await?;
     audit_control(&mut transaction, id, &actor, "team.delete", "succeeded").await?;
+    // `grants` references `policies` with ON DELETE RESTRICT while `policies`
+    // cascades from `teams`, so deleting the team aborts unless its grants go
+    // first. Revocation is a tombstone rather than a row delete, so even a fully
+    // revoked team would otherwise be undeletable. Deleting the grants cascades
+    // their invitations, sessions and durable requests; audit rows survive with
+    // their team and grant links cleared.
+    query("DELETE FROM grants WHERE team_id = ?")
+        .bind(id)
+        .execute(&mut *transaction)
+        .await?;
     let result = query("DELETE FROM teams WHERE id = ?")
         .bind(id)
         .execute(&mut *transaction)
@@ -119,7 +129,7 @@ pub async fn delete_team(
         return Err(ApiError::NotFound);
     }
     transaction.commit().await?;
-    state.signer.request(&LifecycleRequest::Reload).await?;
+    state.signer.request(LifecycleRequest::Reload).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -217,7 +227,7 @@ pub async fn add_key(
     require_admin(&state.db, id, &event.pubkey.to_hex()).await?;
     let response = state
         .signer
-        .request(&LifecycleRequest::SealStoredKey {
+        .request(LifecycleRequest::SealStoredKey {
             team_id: id,
             actor_public_key: event.pubkey.to_hex(),
             name: request.name,
@@ -258,7 +268,7 @@ pub async fn remove_key(
     )
     .await?;
     transaction.commit().await?;
-    state.signer.request(&LifecycleRequest::Reload).await?;
+    state.signer.request(LifecycleRequest::Reload).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -405,7 +415,7 @@ pub async fn update_policy(
     }
     audit_control(&mut transaction, id, &actor, "policy.update", "succeeded").await?;
     transaction.commit().await?;
-    state.signer.request(&LifecycleRequest::Reload).await?;
+    state.signer.request(LifecycleRequest::Reload).await?;
     Ok(Json(policy(&state.db, id, policy_id).await?))
 }
 
@@ -454,7 +464,7 @@ pub async fn add_grant(
     let stored_key = stored_key_by_pubkey(&state.db, id, &pubkey).await?;
     let response = state
         .signer
-        .request(&LifecycleRequest::CreateGrant {
+        .request(LifecycleRequest::CreateGrant {
             team_id: id,
             actor_public_key: event.pubkey.to_hex(),
             stored_key_id: stored_key.id,
@@ -485,7 +495,7 @@ pub async fn revoke_grant(
     require_grant_for_key(&state.db, id, &pubkey, grant_id).await?;
     match state
         .signer
-        .request(&LifecycleRequest::RevokeGrant {
+        .request(LifecycleRequest::RevokeGrant {
             grant_id,
             actor_public_key: event.pubkey.to_hex(),
         })
@@ -506,7 +516,7 @@ pub async fn create_invitation(
     require_grant_for_team(&state.db, id, grant_id).await?;
     match state
         .signer
-        .request(&LifecycleRequest::CreateInvitation {
+        .request(LifecycleRequest::CreateInvitation {
             grant_id,
             actor_public_key: event.pubkey.to_hex(),
             expires_at: request.expires_at,
@@ -546,7 +556,7 @@ pub async fn revoke_invitation(
     }
     match state
         .signer
-        .request(&LifecycleRequest::RevokeInvitation {
+        .request(LifecycleRequest::RevokeInvitation {
             invitation_id,
             actor_public_key: event.pubkey.to_hex(),
         })
@@ -657,7 +667,7 @@ pub async fn status(
         query_scalar("SELECT minimum_connected_relays FROM instance_settings WHERE singleton = 1")
             .fetch_one(&state.db)
             .await?;
-    match state.signer.request(&LifecycleRequest::Status).await? {
+    match state.signer.request(LifecycleRequest::Status).await? {
         ControlResponse::Status { status } => Ok(Json(StatusResponse {
             signer: status,
             database_ok,
@@ -749,7 +759,7 @@ pub async fn update_relays(
         .execute(&mut *transaction)
         .await?;
     transaction.commit().await?;
-    state.signer.request(&LifecycleRequest::Reload).await?;
+    state.signer.request(LifecycleRequest::Reload).await?;
 
     let rows: Vec<(
         i64,
@@ -1078,6 +1088,6 @@ pub async fn update_discovery_policy(
         .execute(&mut *tx)
         .await?;
     tx.commit().await?;
-    state.signer.request(&LifecycleRequest::Reload).await?;
+    state.signer.request(LifecycleRequest::Reload).await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/signer/src/management/api/types.rs
+++ b/signer/src/management/api/types.rs
@@ -37,11 +37,14 @@ impl TeamRole {
     }
 }
 
+/// `Secret` keeps the imported private key out of `Debug` output and erases its
+/// buffer on drop. Intermediate copies inside the HTTP and JSON layers cannot be
+/// erased from here, so the trusted CLI remains the stronger import path.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AddKeyRequest {
     pub name: String,
-    pub secret_key: String,
+    pub secret_key: keycast_core::v2::secret::Secret,
 }
 
 #[derive(Debug, Deserialize)]

--- a/signer/src/management/state.rs
+++ b/signer/src/management/state.rs
@@ -22,11 +22,12 @@ pub enum SignerClientError {
     Rejected { code: String, message: String },
 }
 impl SignerClient {
+    /// Taken by value: cloning would duplicate imported private material.
     pub async fn request(
         &self,
-        request: &LifecycleRequest,
+        request: LifecycleRequest,
     ) -> Result<ControlResponse, SignerClientError> {
-        match crate::control::dispatch_lifecycle(&self.runtime, request.clone()).await {
+        match crate::control::dispatch_lifecycle(&self.runtime, request).await {
             ControlResponse::Error { code, message } => {
                 Err(SignerClientError::Rejected { code, message })
             }

--- a/signer/src/protocol.rs
+++ b/signer/src/protocol.rs
@@ -731,13 +731,11 @@ fn parse_sign_event_template(
             return Err(SignEventTemplateError::Invalid);
         }
     }
-    if object
-        .get("id")
-        .and_then(Value::as_str)
-        .is_some_and(|id| id.len() == 64 && id.bytes().all(|b| b == b'0'))
-    {
-        object.remove("id");
-    }
+    // Always drop a client-supplied id and recompute it while signing. The nostr
+    // crate signs `unsigned.id` before verifying it, so forwarding one would make
+    // the signer produce a Schnorr signature over an attacker-chosen 32-byte value
+    // even though the mismatch is rejected afterwards.
+    object.remove("id");
 
     match object.get("pubkey") {
         None => {
@@ -906,6 +904,27 @@ mod tests {
             .expect("nak unsigned full-event representation");
         assert_eq!(parsed.pubkey, user);
         assert_eq!(parsed.id, None);
+    }
+
+    #[test]
+    fn sign_event_never_signs_a_client_supplied_id() {
+        let user = Keys::generate().public_key();
+        let mut template = json!({
+            "kind": 1,
+            "content": "hello",
+            "tags": [],
+            "created_at": Timestamp::now().as_secs()
+        });
+        let canonical = parse_sign_event_template(&template.to_string(), &user)
+            .expect("canonical template")
+            .compute_id();
+
+        // A forged id must never reach the signing call, and must not change the result.
+        template["id"] = Value::String("f".repeat(64));
+        let parsed = parse_sign_event_template(&template.to_string(), &user)
+            .expect("template with a forged id");
+        assert_eq!(parsed.id, None);
+        assert_eq!(parsed.compute_id(), canonical);
     }
 
     #[test]

--- a/signer/src/runtime.rs
+++ b/signer/src/runtime.rs
@@ -11,7 +11,7 @@ use nostr_sdk::prelude::{Client, ClientNotification, StreamExt};
 use thiserror::Error;
 use tokio::sync::{watch, Notify};
 
-use crate::admission::{Admission, RelayCopies};
+use crate::admission::{Admission, Limits, RelayCopies};
 use crate::control::serve_control_socket;
 use crate::protocol::{recipient, validate_outer_event, RequestProcessor, RuntimeMetrics};
 use crate::store::{Store, StoreError};
@@ -76,6 +76,7 @@ impl RuntimeState {
             schema_version: SCHEMA_VERSION,
             envelope_version: ENVELOPE_VERSION,
             credential_key_id: Some(self.store.cipher.key_id().to_string()),
+            management_reply_public_key: self.store.cipher.management_reply_public_key(),
             active_grants: grants,
             active_sessions: sessions,
             claimable_invitations: invitations,
@@ -232,8 +233,14 @@ pub async fn relay_supervisor(
     let mut prune = tokio::time::interval(Duration::from_secs(5));
     let mut maintenance = tokio::time::interval(Duration::from_secs(60));
     let mut integrity = tokio::time::interval(Duration::from_secs(3600));
-    let admission = Admission::default();
+    let admission = Admission::new(Limits::ESTABLISHED);
+    // Events from clients without a live session on the target grant, including
+    // every `connect`, draw from their own smaller lane.
+    let newcomers = Admission::new(Limits::NEWCOMER);
     let replay_validation = Admission::default();
+    // (remote signer pubkey, client pubkey) pairs with a live session, refreshed
+    // with the grant configuration. Bounded by the sessions capacity trigger.
+    let mut live_sessions = HashSet::<(String, String)>::new();
     let mut minimum = 1i64;
     let mut recovery_pending = false;
     let mut delivery_failure: Option<std::time::Instant> = None;
@@ -307,7 +314,16 @@ pub async fn relay_supervisor(
                                     telemetry.record(relay_url.as_str(), category);
                                     return Ok(true);
                                 }
-                                let ticket = match admission.try_admit_reason(&peer, &target.to_hex()) {
+                                // Choose the lane before spending any budget: a forged flood
+                                // addressed to a public remote-signer key must not be able to
+                                // exhaust the capacity that established sessions rely on.
+                                let target_hex = target.to_hex();
+                                let lane = if live_sessions.contains(&(target_hex.clone(), peer.clone())) {
+                                    &admission
+                                } else {
+                                    &newcomers
+                                };
+                                let ticket = match lane.try_admit_reason(&peer, &target_hex) {
                                     Ok(ticket) => ticket,
                                     Err(reason) => {
                                         state.metrics.ingress_rejections.fetch_add(1,Ordering::Relaxed);
@@ -408,6 +424,9 @@ pub async fn relay_supervisor(
                     completed = sqlx::query_scalar::query_scalar::<_, String>("SELECT event_id FROM processed_requests WHERE response_event_json IS NOT NULL ORDER BY received_at DESC LIMIT 10000")
                         .fetch_all(&state.store.pool).await?.into_iter().collect();
                     let grants = state.store.active_grants().await?;
+                    live_sessions = sqlx::query_as::query_as::<_, (String, String)>(
+                        "SELECT g.remote_signer_public_key,s.client_public_key FROM sessions s JOIN grants g ON g.id=s.grant_id WHERE s.ended_at IS NULL AND g.revoked_at IS NULL AND (g.expires_at IS NULL OR g.expires_at>unixepoch())")
+                        .fetch_all(&state.store.pool).await?.into_iter().collect();
                     let mut public_keys = BTreeSet::new();
                     let mut desired_keys = BTreeMap::<String,BTreeSet<PublicKey>>::new();
                     baseline=state.store.enabled_relays().await?.into_iter().map(|u|u.trim_end_matches('/').to_owned()).collect();

--- a/signer/src/runtime.rs
+++ b/signer/src/runtime.rs
@@ -31,6 +31,8 @@ pub struct RuntimeState {
     pub quarantined_grants: Arc<AtomicUsize>,
     pub reload: Arc<Notify>,
     pub last_progress: Arc<AtomicU64>,
+    /// Completed configuration refreshes, including the live-session index.
+    pub configuration_reloads: Arc<AtomicU64>,
 }
 
 #[derive(Debug, Error)]
@@ -57,6 +59,7 @@ impl RuntimeState {
             quarantined_grants: Arc::new(AtomicUsize::new(0)),
             reload: Arc::new(Notify::new()),
             last_progress: Arc::new(AtomicU64::new(progress_tick())),
+            configuration_reloads: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -519,6 +522,7 @@ pub async fn relay_supervisor(
                             worker_events.insert(task.id(), worker_id);
                         }
                     }
+                    state.configuration_reloads.fetch_add(1, Ordering::Relaxed);
                 }
                 _ = discovery_tick.tick(), if discovery_jobs.is_empty() => {
                     let store=state.store.clone();

--- a/signer/tests/hardening.rs
+++ b/signer/tests/hardening.rs
@@ -1015,6 +1015,83 @@ async fn runtime_isolates_noisy_grant_before_waiting_for_authority() {
     relay.shutdown();
 }
 
+#[tokio::test]
+async fn forged_flood_cannot_starve_a_client_that_already_holds_a_session() {
+    // A grant's remote-signer public key is published in every bunker URI and in
+    // every client request, so anyone can address events to it. Admission must
+    // not let that traffic consume the capacity a live session depends on.
+    let relay = LocalRelay::new();
+    relay.run().await.unwrap();
+    let f = Fixture::new(relay.url().await.as_str()).await;
+    let observer = Client::new();
+    observer.add_relay(relay.url().await).await.unwrap();
+    let mut stream = observer.notifications();
+    observer.connect().and_wait(Duration::from_secs(2)).await;
+    observer
+        .subscribe(
+            Filter::new()
+                .kind(Kind::NostrConnect)
+                .pubkey(f.client.public_key()),
+        )
+        .await
+        .unwrap();
+    let state = RuntimeState::new(f.store.clone());
+    let (stop, rx) = tokio::sync::watch::channel(false);
+    let task = tokio::spawn(relay_supervisor(state.clone(), rx));
+    ready(&state).await;
+
+    // Establish the session that must survive the flood.
+    observer.send_event(&f.connect()).await.unwrap();
+    assert_eq!(reply(&mut stream, "connect", &f).await["result"], "ack");
+    let sessions: i64 = query_scalar("SELECT count(*) FROM sessions WHERE ended_at IS NULL")
+        .fetch_one(&f.store.pool)
+        .await
+        .unwrap();
+    assert_eq!(sessions, 1);
+    // Let the runtime pick the new session up into its live-session index.
+    for _ in 0..40 {
+        state.reload.notify_waiters();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Hold the authority gate so admitted workers occupy their lane, then flood
+    // from rotating keys the way an attacker on a shared relay would.
+    let authority = f.store.authority.lock().await;
+    let before = state.metrics.ingress_rejections.load(Ordering::Relaxed);
+    for n in 0..24 {
+        let attacker = Keys::generate();
+        let forged = EventBuilder::new(Kind::NostrConnect, format!("forged-{n}"))
+            .tag(Tag::public_key(f.remote.public_key()))
+            .finalize(&attacker)
+            .unwrap();
+        observer.send_event(&forged).await.unwrap();
+    }
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while state.metrics.ingress_rejections.load(Ordering::Relaxed) <= before {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the newcomer lane rejects a forged flood");
+
+    // The established client is served from its own lane while that flood is
+    // still being rejected. Before the lanes were split this ping was dropped.
+    observer
+        .send_event(&f.event("ping-under-flood", "ping", vec![]))
+        .await
+        .unwrap();
+    drop(authority);
+    assert_eq!(
+        reply(&mut stream, "ping-under-flood", &f).await["result"],
+        "pong"
+    );
+
+    stop.send(true).unwrap();
+    task.await.unwrap().unwrap();
+    observer.shutdown().await;
+    relay.shutdown();
+}
+
 include!("support/process_recovery.rs");
 
 #[tokio::test]

--- a/signer/tests/hardening.rs
+++ b/signer/tests/hardening.rs
@@ -1048,11 +1048,18 @@ async fn forged_flood_cannot_starve_a_client_that_already_holds_a_session() {
         .await
         .unwrap();
     assert_eq!(sessions, 1);
-    // Let the runtime pick the new session up into its live-session index.
-    for _ in 0..40 {
-        state.reload.notify_waiters();
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+    // Wait for the live-session index rather than guessing. `notify_one` retains
+    // a permit when the supervisor is busy in another branch, so the wake cannot
+    // be lost the way `notify_waiters` can.
+    let reloads = state.configuration_reloads.load(Ordering::Relaxed);
+    state.reload.notify_one();
+    tokio::time::timeout(Duration::from_secs(15), async {
+        while state.configuration_reloads.load(Ordering::Relaxed) <= reloads {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("configuration refresh rebuilds the live-session index");
 
     // Hold the authority gate so admitted workers occupy their lane, then flood
     // from rotating keys the way an attacker on a shared relay would.

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -10,6 +10,10 @@ function applySecurityHeaders(response: Response, event: Parameters<Handle>[0]["
     response.headers.set("X-Content-Type-Options", "nosniff");
     response.headers.set("X-Frame-Options", "DENY");
     response.headers.set("Referrer-Policy", "no-referrer");
+    // A remote signer supplies the auth_url we open; COOP stops that popup from
+    // reaching back into this window, and CORP blocks cross-origin embedding.
+    response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
+    response.headers.set("Cross-Origin-Resource-Policy", "same-origin");
     response.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
 
     const forwardedProto = event.request.headers.get("x-forwarded-proto");

--- a/web/src/lib/components/GrantEditor.svelte
+++ b/web/src/lib/components/GrantEditor.svelte
@@ -20,6 +20,9 @@
         onDone,
     }: { id: string; pubkey: string; onDone?: () => void | Promise<void> } =
         $props();
+    // A crafted link can put anything in the route parameter, which would then be
+    // signed into the `u` tag of an approval the operator is asked to confirm.
+    const invalidPubkey = $derived(!/^[0-9a-f]{64}$/.test(pubkey));
     const api = new KeycastApi();
     const user = $derived(getCurrentUser()?.user);
     let isLoading = $state(true);
@@ -35,7 +38,7 @@
     let isSaving = $state(false);
 
     $effect(() => {
-        if (!user?.pubkey || !isLoading) return;
+        if (!user?.pubkey || !isLoading || invalidPubkey) return;
         api.buildAuthHeader(`/teams/${id}`, "GET", user.pubkey)
             .then((authorization) =>
                 api.get<TeamWithRelations>(`/teams/${id}`, {
@@ -96,7 +99,14 @@
     }
 </script>
 
-{#if isLoading}
+{#if invalidPubkey}
+    <div role="alert">
+        <p class="input-error">
+            That is not a valid Nostr public key. Start from your workspace
+            instead of following the link.
+        </p>
+    </div>
+{:else if isLoading}
     <Loader />
 {:else if bunkerUri}
     <h2 class="page-header">Invitation ready</h2>

--- a/web/src/lib/components/KeyImport.svelte
+++ b/web/src/lib/components/KeyImport.svelte
@@ -66,7 +66,10 @@
                 id="key-secret"
                 type="password"
                 required
-                autocomplete="off"
+                autocomplete="one-time-code"
+                data-1p-ignore
+                data-lpignore="true"
+                data-bwignore
                 spellcheck="false"
                 bind:value={secretKey}
                 placeholder="nsec1…"

--- a/web/src/lib/components/KeyPanel.svelte
+++ b/web/src/lib/components/KeyPanel.svelte
@@ -23,6 +23,9 @@
         onRemoved,
     }: { id: string; pubkey: string; onRemoved?: () => void | Promise<void> } =
         $props();
+    // A crafted link can put anything in the route parameter, which would then be
+    // signed into the `u` tag of an approval the operator is asked to confirm.
+    const invalidPubkey = $derived(!/^[0-9a-f]{64}$/.test(pubkey));
     let addingGrant = $state(false);
     let started = $state(false);
     const api = new KeycastApi();
@@ -36,7 +39,7 @@
     let loadError: string | null = $state(null);
 
     $effect(() => {
-        if (!user?.pubkey || started) return;
+        if (!user?.pubkey || started || invalidPubkey) return;
         started = true;
         void load();
     });
@@ -204,7 +207,14 @@
     }
 </script>
 
-{#if isLoading}
+{#if invalidPubkey}
+    <div role="alert">
+        <p class="input-error">
+            That is not a valid Nostr public key. Open the key from your
+            workspace instead of following the link.
+        </p>
+    </div>
+{:else if isLoading}
     <Loader />
 {:else if loadError}
     <div role="alert">

--- a/web/src/lib/current_user.svelte.ts
+++ b/web/src/lib/current_user.svelte.ts
@@ -1,8 +1,4 @@
-import {
-    loadFollowPubkeys,
-    userFromPubkey,
-    type NostrUser,
-} from "$lib/nostr";
+import { userFromPubkey, type NostrUser } from "$lib/nostr";
 
 let currentUser: CurrentUser | null = $state(null);
 
@@ -10,22 +6,8 @@ class CurrentUser {
     /** The Nostr user currently signed in through a browser, remote, or Android signer. */
     user: NostrUser | null = $state(null);
 
-    /** Array of pubkeys that the current user follows */
-    follows: string[] = $state([]);
-
     constructor(pubkey: string) {
         this.user = userFromPubkey(pubkey);
-        if (this.user) {
-            this.fetchUserFollows();
-        }
-    }
-
-    async fetchUserFollows(): Promise<string[]> {
-        if (!this.user) return [];
-
-        const follows = await loadFollowPubkeys(this.user.pubkey);
-        this.follows = follows;
-        return follows;
     }
 }
 

--- a/web/src/lib/keycast_api.svelte.ts
+++ b/web/src/lib/keycast_api.svelte.ts
@@ -1,7 +1,13 @@
 import { generateSecretKey, getPublicKey } from "nostr-tools/pure";
 import { v2 as nip44 } from "nostr-tools/nip44";
 import { sha256Hex } from "./utils/http_auth";
-import { MANAGEMENT_KIND, MANAGEMENT_READ_KIND, managementDescription } from "./utils/management";
+import {
+    MANAGEMENT_KIND,
+    MANAGEMENT_READ_KIND,
+    containsSecretMarker,
+    managementDescription,
+} from "./utils/management";
+import { verifyManagementReplyKey } from "./utils/reply_identity";
 import type { EventTemplate, NostrEvent } from "applesauce-core/helpers";
 import { getContext, setContext } from "svelte";
 import { signNostrEvent } from "./nostr";
@@ -13,7 +19,10 @@ import {
 
 export class KeycastApi {
     private baseUrl: string;
-    private pending = new Map<string, { secret: Uint8Array; created: number }>();
+    private pending = new Map<
+        string,
+        { secret: Uint8Array; created: number; replyKey: string }
+    >();
     private defaultHeaders: HeadersInit;
 
     constructor() {
@@ -46,7 +55,15 @@ export class KeycastApi {
             response = await fetch(url, { ...options, headers, signal: options.signal ?? AbortSignal.timeout(20000) });
             if (pending && response.ok) {
                 const envelope = await response.json() as { encrypted_response: string; public_key: string };
-                const plaintext = nip44.decrypt(envelope.encrypted_response, nip44.utils.getConversationKey(pending.secret, envelope.public_key));
+                // Decrypt against the identity pinned when the approval was signed,
+                // never the one the response claims: that is what makes NIP-44
+                // authenticate the sender rather than merely hide the reply.
+                if (envelope.public_key !== pending.replyKey) {
+                    throw new Error(
+                        "The management reply came from an unexpected identity. Compare the reply identity on the Status page with your host before retrying.",
+                    );
+                }
+                const plaintext = nip44.decrypt(envelope.encrypted_response, nip44.utils.getConversationKey(pending.secret, pending.replyKey));
                 const reply = JSON.parse(plaintext) as { status: number; body: string };
                 response = new Response(reply.status === 204 ? null : reply.body, { status: reply.status });
             }
@@ -142,14 +159,24 @@ export class KeycastApi {
         const write = method !== "GET";
         const unsignedAuthEvent = await this.buildUnsignedAuthEvent(url, method, body);
         let responseSecret: Uint8Array | undefined;
-        const config = await this.get<{ instance_id: string; authority_revision: number }>("/config", { params: { pubkey } });
+        const config = await this.get<{ instance_id: string; authority_revision: number; management_reply_public_key: string }>("/config", { params: { pubkey } });
         if (!config.instance_id || !Number.isSafeInteger(config.authority_revision)) throw new Error("Signer management configuration is unavailable");
         unsignedAuthEvent.tags.push(["instance", config.instance_id]);
+        let replyKey = "";
         if (write) {
+            replyKey = verifyManagementReplyKey(config.management_reply_public_key);
             responseSecret = generateSecretKey();
             const nonce = Array.from(crypto.getRandomValues(new Uint8Array(32)), b => b.toString(16).padStart(2,"0")).join("");
             unsignedAuthEvent.kind = MANAGEMENT_KIND;
             unsignedAuthEvent.content = managementDescription(method, url, body ?? "");
+            // Refuse before asking the key store to sign. The approval is shown by,
+            // stored in, and for NIP-46 relayed to an external signer.
+            if (containsSecretMarker(unsignedAuthEvent.content)) {
+                responseSecret.fill(0);
+                throw new Error(
+                    "This change cannot be approved because its description would contain private key material. Remove the key material from the name and try again.",
+                );
+            }
             unsignedAuthEvent.tags = unsignedAuthEvent.tags.filter(t => t[0] !== "payload");
             unsignedAuthEvent.tags.push(["payload", await sha256Hex(body ?? "")], ["revision", String(config.authority_revision)], ["nonce", nonce], ["response", getPublicKey(responseSecret)]);
         }
@@ -163,7 +190,7 @@ export class KeycastApi {
                 }
             }
             if (responseSecret) {
-                this.pending.set(header,{secret:responseSecret,created:Date.now()});
+                this.pending.set(header,{secret:responseSecret,created:Date.now(),replyKey});
                 setTimeout(() => { const value = this.pending.get(header); if (value) { value.secret.fill(0); this.pending.delete(header); } }, 120000);
             }
             return header;

--- a/web/src/lib/keycast_api.test.ts
+++ b/web/src/lib/keycast_api.test.ts
@@ -11,11 +11,13 @@ beforeEach(() => setActiveSigner({kind:"extension",pubkey,signer:{getPublicKey:a
 const originalFetch = globalThis.fetch;
 afterEach(() => { globalThis.fetch = originalFetch; clearActiveSigner(); });
 function eventFrom(header: string) { return JSON.parse(Buffer.from(header.slice(6), "base64").toString("utf8")); }
-function configuration() { return Response.json({ instance_id: "test-instance", authority_revision: 4 }); }
-function encryptedReply(header: string, status: number, body: string) {
+// The signer publishes one stable reply identity; a reply from anything else is a forgery.
+const replySecret = generateSecretKey();
+const replyPublicKey = getPublicKey(replySecret);
+function configuration() { return Response.json({ instance_id: "test-instance", authority_revision: 4, management_reply_public_key: replyPublicKey }); }
+function encryptedReply(header: string, status: number, body: string, sender: Uint8Array = replySecret) {
     const approval = eventFrom(header);
     const recipient = approval.tags.find((tag: string[]) => tag[0] === "response")[1];
-    const sender = generateSecretKey();
     return Response.json({ public_key: getPublicKey(sender), encrypted_response: nip44.encrypt(JSON.stringify({status, body}), nip44.utils.getConversationKey(sender, recipient)) });
 }
 describe("management HTTP encryption and external approvals", () => {
@@ -75,6 +77,22 @@ describe("management HTTP encryption and external approvals", () => {
         expect(event.tags).toContainEqual(["instance", "test-instance"]);
         expect(event.tags.some((t:string[])=>t[0]==="response")).toBe(false);
         expect(await api.get<{ok:boolean}>("/teams", {headers:{Authorization:header}})).toEqual({ok:true});
+    });
+    test("refuses a reply encrypted by any identity other than the published one", async () => {
+        const api = new KeycastApi(); let header = "";
+        globalThis.fetch = mock(async (url: string | URL | Request) => String(url).includes("/config?") ? configuration() : encryptedReply(header, 201, '{"id":1}', generateSecretKey())) as unknown as typeof fetch;
+        header = await api.buildAuthHeader("/teams", "POST", pubkey, '{"name":"Ops"}');
+        await expect(api.post("/teams", {name:"Ops"}, {headers:{Authorization:header}})).rejects.toThrow("unexpected identity");
+    });
+    test("requires the signer to publish a management reply identity for writes", async () => {
+        globalThis.fetch = mock(async () => Response.json({instance_id:"test-instance",authority_revision:4})) as unknown as typeof fetch;
+        await expect(new KeycastApi().buildAuthHeader("/teams","POST",pubkey,'{"name":"Ops"}')).rejects.toThrow("management reply identity");
+    });
+    test("refuses to sign an approval whose description would carry private material", async () => {
+        globalThis.fetch = mock(async () => configuration()) as unknown as typeof fetch;
+        const api = new KeycastApi();
+        await expect(api.buildAuthHeader("/teams/1", "PUT", pubkey, '{"secret_key":"nsec1abc"}')).rejects.toThrow("private key material");
+        await expect(api.buildAuthHeader("/teams/1/keys", "POST", pubkey, '{"name":"nsec1pasted","secret_key":"x"}')).rejects.toThrow("private key material");
     });
     test("refuses unsafe authority revisions before requesting a signature", async () => {
         globalThis.fetch = mock(async () => Response.json({instance_id:"test",authority_revision: 9007199254740992})) as unknown as typeof fetch;

--- a/web/src/lib/nostr.ts
+++ b/web/src/lib/nostr.ts
@@ -9,7 +9,7 @@ import { createEventLoaderForStore } from "applesauce-loaders/loaders";
 import { RelayPool } from "applesauce-relay";
 import type { ISigner } from "applesauce-signers";
 import { ExtensionSigner, NostrConnectSigner } from "applesauce-signers";
-import { catchError, firstValueFrom, of, timeout, takeUntil, timer, toArray, filter, take } from "rxjs";
+import { catchError, firstValueFrom, of, takeUntil, timer, toArray, filter, take } from "rxjs";
 import {
     DEFAULT_NOSTR_READ_RELAYS,
     DEFAULT_OUTBOX_RELAYS,
@@ -43,7 +43,6 @@ export type NostrConnectSigninOptions = {
 };
 
 const PROFILE_LOAD_TIMEOUT_MS = 5000;
-const CONTACTS_LOAD_TIMEOUT_MS = 5000;
 export const DEFAULT_NOSTR_CONNECT_RELAYS = [
     ...REQUIRED_PUBLIC_RELAYS,
 ] as const;
@@ -58,7 +57,8 @@ const loaderRelays = Array.from(
 
 createEventLoaderForStore(eventStore, relayPool, {
     bufferTime: 1000,
-    followRelayHints: true,
+    // Do not open connections to relays named inside fetched events.
+    followRelayHints: false,
     extraRelays: [...DEFAULT_NOSTR_READ_RELAYS],
     lookupRelays: loaderRelays,
 });
@@ -225,7 +225,14 @@ export async function signNostrEvent(
     template: EventTemplate,
     expectedPubkey?: string,
 ): Promise<NostrEvent> {
-    const signer = activeSigner?.signer ?? getExtensionSigner();
+    // After a reload the cookie can outlive the signer connection. Say so instead
+    // of silently prompting whichever extension happens to be installed.
+    if (!activeSigner) {
+        throw new Error(
+            "Your signer is no longer connected. Sign in again to approve this change.",
+        );
+    }
+    const signer = activeSigner.signer;
     const normalizedExpectedPubkey = expectedPubkey
         ? normalizePubkey(expectedPubkey)
         : null;
@@ -278,15 +285,31 @@ function disposeSigner(signer: ISigner | null | undefined): void {
     disposable?.destroy?.();
 }
 
+/**
+ * The remote signer chooses this URL, so treat it as untrusted input: require
+ * https and open with `noopener` so the popup cannot navigate this window to a
+ * look-alike page while the operator is signing in.
+ */
 function openSignerAuthChallenge(url: string): Promise<void> {
-    if (typeof window !== "undefined") {
-        window.open(
-            url,
-            "keycast-signer-auth",
-            "width=420,height=640,resizable=yes,status=no,location=yes,toolbar=no,menubar=no",
+    if (typeof window === "undefined") return Promise.resolve();
+
+    let target: URL;
+    try {
+        target = new URL(url);
+    } catch {
+        return Promise.reject(new Error("The signer sent an invalid authorization URL"));
+    }
+    if (target.protocol !== "https:") {
+        return Promise.reject(
+            new Error(`The signer requested a non-HTTPS authorization URL (${target.protocol})`),
         );
     }
 
+    window.open(
+        target.href,
+        "keycast-signer-auth",
+        "noopener,noreferrer,width=420,height=640,resizable=yes,status=no,location=yes,toolbar=no,menubar=no",
+    );
     return Promise.resolve();
 }
 
@@ -307,20 +330,3 @@ export async function loadProfile(
     return profileCache.load(normalized);
 }
 
-export async function loadFollowPubkeys(
-    pubkey: string | null | undefined,
-): Promise<string[]> {
-    const normalized = pubkey ? normalizePubkey(pubkey) : null;
-    if (!normalized) return [];
-
-    const contacts = await firstValueFrom(
-        eventStore.contacts(normalized).pipe(
-            timeout({ first: CONTACTS_LOAD_TIMEOUT_MS }),
-            catchError(() => of([])),
-        ),
-    );
-
-    return contacts
-        .map((contact) => normalizePubkey(contact.pubkey))
-        .filter((contactPubkey): contactPubkey is string => !!contactPubkey);
-}

--- a/web/src/lib/server/csp.js
+++ b/web/src/lib/server/csp.js
@@ -19,9 +19,13 @@ const baseDirectives = {
     "form-action": ["self"],
     "script-src": ["self"],
     "style-src": ["self", "unsafe-inline"],
-    "img-src": ["self", "data:", "blob:", "https:", "http:"],
+    // Profile pictures come from arbitrary hosts; upgrade-insecure-requests
+    // rewrites any http: URL, so only https: needs to be allowed.
+    "img-src": ["self", "data:", "blob:", "https:"],
     "font-src": ["self", "data:"],
-    "connect-src": ["self", "https:", "wss:", "ws:"],
+    // The UI talks to its own origin and to Nostr relays over wss:. A blanket
+    // https: source would be an open exfiltration channel if XSS ever landed.
+    "connect-src": ["self", "wss:"],
     "upgrade-insecure-requests": true,
 };
 

--- a/web/src/lib/server/csp.js
+++ b/web/src/lib/server/csp.js
@@ -30,9 +30,13 @@ const baseDirectives = {
 };
 
 /**
- * Permit only the configured local API origin for split-port development.
- * HTTP loopback has no TLS endpoint, so upgrading its requests would break it.
- * Production and remote HTTPS configurations retain the default policy.
+ * Permit exactly the configured API origin.
+ *
+ * `connect-src` no longer carries a blanket `https:`, so a split-origin
+ * deployment must name its API explicitly or every management request is
+ * blocked. Same-origin deployments are already covered by `'self'`; adding the
+ * origin again is harmless. HTTP is accepted only on loopback, where there is no
+ * TLS endpoint to upgrade to.
  * @param {string | undefined} apiUrl
  * @returns {CspDirectiveMap}
  */
@@ -45,13 +49,20 @@ export function createCspDirectives(apiUrl) {
     );
     if (!apiUrl) return directives;
     const url = new URL(apiUrl);
-    if (url.protocol !== "http:") return directives;
-    if (!["localhost", "127.0.0.1", "[::1]"].includes(url.hostname)) {
+    if (url.protocol !== "http:" && url.protocol !== "https:") return directives;
+    if (
+        url.protocol === "http:" &&
+        !["localhost", "127.0.0.1", "[::1]"].includes(url.hostname)
+    ) {
         throw new Error("HTTP API origins are supported only on loopback");
     }
     const sources = directives["connect-src"];
-    if (Array.isArray(sources)) sources.push(url.origin);
-    delete directives["upgrade-insecure-requests"];
+    if (Array.isArray(sources) && !sources.includes(url.origin)) {
+        sources.push(url.origin);
+    }
+    if (url.protocol === "http:") {
+        delete directives["upgrade-insecure-requests"];
+    }
     return directives;
 }
 

--- a/web/src/lib/server/csp.test.ts
+++ b/web/src/lib/server/csp.test.ts
@@ -20,12 +20,8 @@ describe("configured API content security policy", () => {
         for (const api of [undefined, "https://keycast.example"]) {
             const policy = createCspDirectives(api);
             expect(policy["upgrade-insecure-requests"]).toBe(true);
-            expect(policy["connect-src"]).toEqual([
-                "self",
-                "https:",
-                "wss:",
-                "ws:",
-            ]);
+            expect(policy["connect-src"]).toEqual(["self", "wss:"]);
+            expect(policy["img-src"]).not.toContain("http:");
         }
     });
     test("rejects HTTP origins that only resemble loopback", () => {

--- a/web/src/lib/server/csp.test.ts
+++ b/web/src/lib/server/csp.test.ts
@@ -17,12 +17,36 @@ describe("configured API content security policy", () => {
     });
     test("keeps production upgrade policy and never leaks local origins between configurations", () => {
         createCspDirectives("http://localhost:3101");
-        for (const api of [undefined, "https://keycast.example"]) {
-            const policy = createCspDirectives(api);
-            expect(policy["upgrade-insecure-requests"]).toBe(true);
-            expect(policy["connect-src"]).toEqual(["self", "wss:"]);
-            expect(policy["img-src"]).not.toContain("http:");
-        }
+        const policy = createCspDirectives(undefined);
+        expect(policy["upgrade-insecure-requests"]).toBe(true);
+        expect(policy["connect-src"]).toEqual(["self", "wss:"]);
+        expect(policy["img-src"]).not.toContain("http:");
+    });
+    test("permits a split-origin HTTPS API without restoring a blanket https: source", () => {
+        // Without this the UI cannot reach /config or any management endpoint
+        // when the API is served from a different origin.
+        const policy = createCspDirectives("https://api.keycast.example/api");
+        expect(policy["connect-src"]).toEqual([
+            "self",
+            "wss:",
+            "https://api.keycast.example",
+        ]);
+        expect(policy["connect-src"]).not.toContain("https:");
+        // HTTPS keeps the upgrade directive; only loopback HTTP drops it.
+        expect(policy["upgrade-insecure-requests"]).toBe(true);
+        // A same-origin API is already covered by 'self' and is not duplicated.
+        const sameOrigin = createCspDirectives("https://keycast.example/api");
+        const sources = sameOrigin["connect-src"];
+        expect(Array.isArray(sources)).toBe(true);
+        expect(
+            (sources as string[]).filter(
+                (source: string) => source === "https://keycast.example",
+            ),
+        ).toHaveLength(1);
+        // Configurations must not leak into one another.
+        expect(createCspDirectives("https://other.example")["connect-src"]).not.toContain(
+            "https://api.keycast.example",
+        );
     });
     test("rejects HTTP origins that only resemble loopback", () => {
         for (const api of [

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -102,6 +102,7 @@ export type SignerStatus = {
     schema_version: number;
     envelope_version: number;
     credential_key_id: string | null;
+    management_reply_public_key: string | null;
     active_grants: number;
     active_sessions: number;
     claimable_invitations: number;

--- a/web/src/lib/utils/management.ts
+++ b/web/src/lib/utils/management.ts
@@ -1,6 +1,13 @@
 // Private Keycast management kind; every Keycast NIP-46 grant denies it.
 export const MANAGEMENT_KIND = 27236;
 export const MANAGEMENT_READ_KIND = 27237;
+/// Mirrors `contains_secret_marker` in core/src/v2/management.rs. An approval is
+/// displayed by, stored in, and for NIP-46 transported to an external key store.
+const SECRET_MARKERS = ["secret_key", "nsec1"];
+export function containsSecretMarker(content: string): boolean {
+    const lowered = content.toLowerCase();
+    return SECRET_MARKERS.some((marker) => lowered.includes(marker));
+}
 export function managementDescription(method: string, path: string, body: string): string {
     if (method === "POST" && path.split("?")[0].endsWith("/keys")) {
         const value = JSON.parse(body) as { name: string };

--- a/web/src/lib/utils/reply_identity.test.ts
+++ b/web/src/lib/utils/reply_identity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import {
     forgetManagementReplyKey,
     isManagementReplyKey,
@@ -23,10 +23,29 @@ function memoryStorage(): Storage {
     } as Storage;
 }
 
+/** A store that throws on every access, like a browser with site data blocked. */
+function throwingStorage(): Storage {
+    const boom = () => {
+        throw new Error("storage is disabled");
+    };
+    return {
+        get length(): number {
+            return boom();
+        },
+        clear: boom,
+        getItem: boom,
+        key: boom,
+        removeItem: boom,
+        setItem: boom,
+    } as unknown as Storage;
+}
+
 const first = "a".repeat(64);
 const second = "b".repeat(64);
 
 describe("management reply identity pinning", () => {
+    beforeEach(() => forgetManagementReplyKey(memoryStorage()));
+
     test("pins on first use and accepts the same identity afterwards", () => {
         const store = memoryStorage();
         expect(pinnedManagementReplyKey(store)).toBeNull();
@@ -82,11 +101,35 @@ describe("management reply identity pinning", () => {
         expect(verifyManagementReplyKey(second, store)).toBe(second);
     });
 
-    test("works without any storage and never throws on a missing store", () => {
+    test("retains the pin in memory when the store is missing", () => {
+        // A first use still establishes a trust anchor for the rest of the session.
         expect(verifyManagementReplyKey(first, undefined)).toBe(first);
-        expect(pinnedManagementReplyKey(undefined)).toBeNull();
+        expect(pinnedManagementReplyKey(undefined)).toBe(first);
+        expect(() => verifyManagementReplyKey(second, undefined)).toThrow(
+            "identity changed",
+        );
         expect(() => forgetManagementReplyKey(undefined)).not.toThrow();
-        expect(() => trustManagementReplyKey(first, undefined)).not.toThrow();
+        expect(pinnedManagementReplyKey(undefined)).toBeNull();
+    });
+
+    test("retains the pin in memory when every storage access throws", () => {
+        const store = throwingStorage();
+        expect(verifyManagementReplyKey(first, store)).toBe(first);
+        expect(pinnedManagementReplyKey(store)).toBe(first);
+        // Without the session pin this second, different key would be accepted
+        // as another first use and a compromised API could swap the identity.
+        expect(() => verifyManagementReplyKey(second, store)).toThrow(
+            "identity changed",
+        );
+        expect(() => trustManagementReplyKey(second, store)).not.toThrow();
+        expect(verifyManagementReplyKey(second, store)).toBe(second);
+    });
+
+    test("a persisted pin outranks a stale session pin", () => {
+        const store = memoryStorage();
+        trustManagementReplyKey(second, undefined);
+        store.setItem("keycast:management-reply-identity:v1", first);
+        expect(pinnedManagementReplyKey(store)).toBe(first);
     });
 
     test("fingerprints are short, stable and never the whole key", () => {

--- a/web/src/lib/utils/reply_identity.test.ts
+++ b/web/src/lib/utils/reply_identity.test.ts
@@ -40,6 +40,31 @@ function throwingStorage(): Storage {
     } as unknown as Storage;
 }
 
+/** Readable until revoked, like storage that stops working mid-session. */
+function revocableStorage(): Storage & { revoke: () => void } {
+    const inner = memoryStorage();
+    let live = true;
+    const guard = <T>(operation: () => T): T => {
+        if (!live) throw new Error("storage is disabled");
+        return operation();
+    };
+    return {
+        get length(): number {
+            return guard(() => inner.length);
+        },
+        clear: () => guard(() => inner.clear()),
+        getItem: (key: string) => guard(() => inner.getItem(key)),
+        key: (index: number) => guard(() => inner.key(index)),
+        removeItem: (key: string) => guard(() => inner.removeItem(key)),
+        setItem: (key: string, value: string) =>
+            guard(() => inner.setItem(key, value)),
+        revoke: () => {
+            live = false;
+        },
+    } as Storage & { revoke: () => void };
+}
+
+const PIN_KEY = "keycast:management-reply-identity:v1";
 const first = "a".repeat(64);
 const second = "b".repeat(64);
 
@@ -128,8 +153,22 @@ describe("management reply identity pinning", () => {
     test("a persisted pin outranks a stale session pin", () => {
         const store = memoryStorage();
         trustManagementReplyKey(second, undefined);
-        store.setItem("keycast:management-reply-identity:v1", first);
+        store.setItem(PIN_KEY, first);
         expect(pinnedManagementReplyKey(store)).toBe(first);
+    });
+
+    test("a pin read from storage survives storage becoming unreadable", () => {
+        // The returning-browser case: a persisted pin and a fresh session, then
+        // storage stops working. Without mirroring the read into memory this
+        // would look like a first use and accept a substituted identity.
+        const store = revocableStorage();
+        store.setItem(PIN_KEY, first);
+        expect(verifyManagementReplyKey(first, store)).toBe(first);
+        store.revoke();
+        expect(() => verifyManagementReplyKey(second, store)).toThrow(
+            "identity changed",
+        );
+        expect(verifyManagementReplyKey(first, store)).toBe(first);
     });
 
     test("fingerprints are short, stable and never the whole key", () => {

--- a/web/src/lib/utils/reply_identity.test.ts
+++ b/web/src/lib/utils/reply_identity.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import {
+    forgetManagementReplyKey,
+    isManagementReplyKey,
+    managementReplyFingerprint,
+    pinnedManagementReplyKey,
+    trustManagementReplyKey,
+    verifyManagementReplyKey,
+} from "./reply_identity";
+
+/** Minimal Storage stand-in; Bun has no localStorage. */
+function memoryStorage(): Storage {
+    const values = new Map<string, string>();
+    return {
+        get length() {
+            return values.size;
+        },
+        clear: () => values.clear(),
+        getItem: (key: string) => values.get(key) ?? null,
+        key: (index: number) => [...values.keys()][index] ?? null,
+        removeItem: (key: string) => void values.delete(key),
+        setItem: (key: string, value: string) => void values.set(key, value),
+    } as Storage;
+}
+
+const first = "a".repeat(64);
+const second = "b".repeat(64);
+
+describe("management reply identity pinning", () => {
+    test("pins on first use and accepts the same identity afterwards", () => {
+        const store = memoryStorage();
+        expect(pinnedManagementReplyKey(store)).toBeNull();
+        expect(verifyManagementReplyKey(first, store)).toBe(first);
+        expect(pinnedManagementReplyKey(store)).toBe(first);
+        expect(verifyManagementReplyKey(first, store)).toBe(first);
+    });
+
+    test("fails closed when the identity changes until it is trusted", () => {
+        const store = memoryStorage();
+        verifyManagementReplyKey(first, store);
+        expect(() => verifyManagementReplyKey(second, store)).toThrow(
+            "identity changed",
+        );
+        // The message must let the operator compare against the host.
+        expect(() => verifyManagementReplyKey(second, store)).toThrow(
+            "keycast_signer status",
+        );
+        trustManagementReplyKey(second, store);
+        expect(verifyManagementReplyKey(second, store)).toBe(second);
+        expect(() => verifyManagementReplyKey(first, store)).toThrow(
+            "identity changed",
+        );
+    });
+
+    test("rejects anything that is not a 32-byte lowercase hex key", () => {
+        const store = memoryStorage();
+        for (const invalid of [
+            undefined,
+            null,
+            "",
+            "zz",
+            "A".repeat(64),
+            "a".repeat(63),
+            "a".repeat(65),
+            123,
+            { pubkey: first },
+        ]) {
+            expect(() => verifyManagementReplyKey(invalid, store)).toThrow(
+                "did not publish a valid management reply identity",
+            );
+            expect(isManagementReplyKey(invalid)).toBe(false);
+        }
+        expect(pinnedManagementReplyKey(store)).toBeNull();
+        expect(() => trustManagementReplyKey("nope", store)).toThrow("Invalid");
+    });
+
+    test("forgetting the pin allows a fresh first use", () => {
+        const store = memoryStorage();
+        verifyManagementReplyKey(first, store);
+        forgetManagementReplyKey(store);
+        expect(pinnedManagementReplyKey(store)).toBeNull();
+        expect(verifyManagementReplyKey(second, store)).toBe(second);
+    });
+
+    test("works without any storage and never throws on a missing store", () => {
+        expect(verifyManagementReplyKey(first, undefined)).toBe(first);
+        expect(pinnedManagementReplyKey(undefined)).toBeNull();
+        expect(() => forgetManagementReplyKey(undefined)).not.toThrow();
+        expect(() => trustManagementReplyKey(first, undefined)).not.toThrow();
+    });
+
+    test("fingerprints are short, stable and never the whole key", () => {
+        expect(managementReplyFingerprint(first)).toBe("aaaaaaaa…aaaaaaaa");
+        expect(managementReplyFingerprint(first).length).toBeLessThan(
+            first.length,
+        );
+        expect(managementReplyFingerprint("nope")).toBe("unknown");
+    });
+});

--- a/web/src/lib/utils/reply_identity.ts
+++ b/web/src/lib/utils/reply_identity.ts
@@ -44,8 +44,15 @@ export function pinnedManagementReplyKey(
     } catch {
         stored = null;
     }
-    // Persisted value wins; the session pin covers a store that cannot be read.
-    return stored ?? sessionPin;
+    if (stored) {
+        // Mirror a persisted pin into memory on every read, not only when one is
+        // established. A returning browser starts each page load with an empty
+        // session pin, so without this the anchor would be lost the moment
+        // storage stopped being readable partway through the session.
+        sessionPin = stored;
+        return stored;
+    }
+    return sessionPin;
 }
 
 export function trustManagementReplyKey(

--- a/web/src/lib/utils/reply_identity.ts
+++ b/web/src/lib/utils/reply_identity.ts
@@ -15,7 +15,14 @@
  */
 const PIN_STORAGE_KEY = "keycast:management-reply-identity:v1";
 
-/** Storage access throws in some privacy modes; treat that as "nothing pinned". */
+/**
+ * Survives a storage failure. Without this, a private mode or a full or disabled
+ * store would make every request a first use, so an API compromised mid-session
+ * could swap the identity in /config and never trip the change warning.
+ */
+let sessionPin: string | null = null;
+
+/** Storage access throws in some privacy modes; treat that as "nothing stored". */
 function browserStorage(): Storage | undefined {
     try {
         return typeof localStorage === "undefined" ? undefined : localStorage;
@@ -31,11 +38,14 @@ export function isManagementReplyKey(value: unknown): value is string {
 export function pinnedManagementReplyKey(
     store: Storage | undefined = browserStorage(),
 ): string | null {
+    let stored: string | null = null;
     try {
-        return store?.getItem(PIN_STORAGE_KEY) ?? null;
+        stored = store?.getItem(PIN_STORAGE_KEY) ?? null;
     } catch {
-        return null;
+        stored = null;
     }
+    // Persisted value wins; the session pin covers a store that cannot be read.
+    return stored ?? sessionPin;
 }
 
 export function trustManagementReplyKey(
@@ -45,20 +55,22 @@ export function trustManagementReplyKey(
     if (!isManagementReplyKey(publicKey)) {
         throw new Error("Invalid management reply identity");
     }
+    sessionPin = publicKey;
     try {
         store?.setItem(PIN_STORAGE_KEY, publicKey);
     } catch {
-        // Without storage the identity is verified per session instead of pinned.
+        // Retained for this session only; the next visit re-pins on first use.
     }
 }
 
 export function forgetManagementReplyKey(
     store: Storage | undefined = browserStorage(),
 ): void {
+    sessionPin = null;
     try {
         store?.removeItem(PIN_STORAGE_KEY);
     } catch {
-        // Nothing was pinned.
+        // Nothing was persisted.
     }
 }
 

--- a/web/src/lib/utils/reply_identity.ts
+++ b/web/src/lib/utils/reply_identity.ts
@@ -1,0 +1,96 @@
+/**
+ * Pins the signer's management reply identity.
+ *
+ * Management write replies are NIP-44 encrypted to a per-request browser key.
+ * NIP-44 authenticates the two parties of the exchange, so it only proves who
+ * sent a reply if this side chooses the sender key instead of reading it out of
+ * the response. The signer derives a stable identity from its root credential
+ * and publishes the public half through `/config`; pinning it here means a
+ * compromised API cannot substitute its own key and fabricate an outcome, such
+ * as a `bunker://` URI pointing at an attacker's signer.
+ *
+ * The pin is per browser. It is a convenience anchor, not the root of trust: the
+ * authoritative check is comparing the fingerprint against
+ * `keycast_signer status` on the host, which the Status page shows.
+ */
+const PIN_STORAGE_KEY = "keycast:management-reply-identity:v1";
+
+/** Storage access throws in some privacy modes; treat that as "nothing pinned". */
+function browserStorage(): Storage | undefined {
+    try {
+        return typeof localStorage === "undefined" ? undefined : localStorage;
+    } catch {
+        return undefined;
+    }
+}
+
+export function isManagementReplyKey(value: unknown): value is string {
+    return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+}
+
+export function pinnedManagementReplyKey(
+    store: Storage | undefined = browserStorage(),
+): string | null {
+    try {
+        return store?.getItem(PIN_STORAGE_KEY) ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export function trustManagementReplyKey(
+    publicKey: string,
+    store: Storage | undefined = browserStorage(),
+): void {
+    if (!isManagementReplyKey(publicKey)) {
+        throw new Error("Invalid management reply identity");
+    }
+    try {
+        store?.setItem(PIN_STORAGE_KEY, publicKey);
+    } catch {
+        // Without storage the identity is verified per session instead of pinned.
+    }
+}
+
+export function forgetManagementReplyKey(
+    store: Storage | undefined = browserStorage(),
+): void {
+    try {
+        store?.removeItem(PIN_STORAGE_KEY);
+    } catch {
+        // Nothing was pinned.
+    }
+}
+
+/** Short form for display and for comparison against the host CLI. */
+export function managementReplyFingerprint(publicKey: string): string {
+    if (!isManagementReplyKey(publicKey)) return "unknown";
+    return `${publicKey.slice(0, 8)}…${publicKey.slice(-8)}`;
+}
+
+/**
+ * Returns the identity to encrypt to, pinning it on first use. Fails closed when
+ * a different identity appears, so the change has to be confirmed deliberately.
+ */
+export function verifyManagementReplyKey(
+    published: unknown,
+    store: Storage | undefined = browserStorage(),
+): string {
+    if (!isManagementReplyKey(published)) {
+        throw new Error(
+            "The signer did not publish a valid management reply identity",
+        );
+    }
+    const pinned = pinnedManagementReplyKey(store);
+    if (!pinned) {
+        trustManagementReplyKey(published, store);
+        return published;
+    }
+    if (pinned !== published) {
+        throw new Error(
+            `This instance's management reply identity changed (pinned ${managementReplyFingerprint(pinned)}, received ${managementReplyFingerprint(published)}). ` +
+                'Compare it with "keycast_signer status" on your host, then trust the new identity on the Status page if you rotated the root credential.',
+        );
+    }
+    return published;
+}

--- a/web/src/routes/(app)/status/+page.svelte
+++ b/web/src/routes/(app)/status/+page.svelte
@@ -11,6 +11,11 @@
         WarningCircle,
     } from "phosphor-svelte";
     import { toast } from "svelte-hot-french-toast";
+    import {
+        managementReplyFingerprint,
+        pinnedManagementReplyKey,
+        trustManagementReplyKey,
+    } from "$lib/utils/reply_identity";
 
     const api = new KeycastApi();
     const user = $derived(getCurrentUser()?.user);
@@ -21,6 +26,27 @@
     let minimumConnectedRelays = $state(1);
     let relayLines = $state("");
     let autoActivate = $state(false);
+    let pinnedReplyKey = $state<string | null>(null);
+    const publishedReplyKey = $derived.by(
+        () => status?.signer.management_reply_public_key ?? null,
+    );
+    // A mismatch means either a deliberate root rotation or a substituted key.
+    const replyKeyChanged = $derived(
+        !!publishedReplyKey &&
+            !!pinnedReplyKey &&
+            publishedReplyKey !== pinnedReplyKey,
+    );
+
+    $effect(() => {
+        pinnedReplyKey = pinnedManagementReplyKey();
+    });
+
+    function trustReplyKey() {
+        if (!publishedReplyKey) return;
+        trustManagementReplyKey(publishedReplyKey);
+        pinnedReplyKey = publishedReplyKey;
+        toast.success("Management reply identity trusted");
+    }
 
     $effect(() => {
         if (user?.pubkey) void refresh();
@@ -233,12 +259,43 @@
         {/each}
     </div>
 
+    {#if replyKeyChanged}
+        <div class="card mb-5" role="alert">
+            <h2 class="text-xl font-bold mb-3 text-warning">
+                Management reply identity changed
+            </h2>
+            <p class="description mb-3">
+                This browser pinned <code
+                    >{managementReplyFingerprint(pinnedReplyKey ?? "")}</code
+                >
+                but the signer now publishes
+                <code>{managementReplyFingerprint(publishedReplyKey ?? "")}</code
+                >. Management writes stay blocked until this is resolved.
+            </p>
+            <p class="description mb-3">
+                Run <code>keycast_signer status</code> on your host and compare
+                its <code>management_reply_public_key</code>. Trust the new
+                identity only if you rotated the root credential yourself.
+            </p>
+            <button class="button button-danger" onclick={trustReplyKey}
+                >Trust this identity</button
+            >
+        </div>
+    {/if}
+
     <div class="card mb-5">
         <h2 class="text-xl font-bold mb-3">Diagnostics</h2>
         <div class="grid sm:grid-cols-2 gap-2 text-sm text-muted">
             <p>
                 Credential fingerprint: <code
                     >{status.signer.credential_key_id ?? "unavailable"}</code
+                >
+            </p>
+            <p>
+                Management reply identity: <code
+                    >{publishedReplyKey
+                        ? managementReplyFingerprint(publishedReplyKey)
+                        : "unavailable"}</code
                 >
             </p>
             <p>Denied requests: {status.signer.denied_requests}</p>

--- a/web/src/routes/(app)/status/+page.svelte
+++ b/web/src/routes/(app)/status/+page.svelte
@@ -12,6 +12,7 @@
     } from "phosphor-svelte";
     import { toast } from "svelte-hot-french-toast";
     import {
+        isManagementReplyKey,
         managementReplyFingerprint,
         pinnedManagementReplyKey,
         trustManagementReplyKey,
@@ -27,9 +28,8 @@
     let relayLines = $state("");
     let autoActivate = $state(false);
     let pinnedReplyKey = $state<string | null>(null);
-    const publishedReplyKey = $derived.by(
-        () => status?.signer.management_reply_public_key ?? null,
-    );
+    let publishedReplyKey = $state<string | null>(null);
+    let replyIdentityError = $state<string | null>(null);
     // A mismatch means either a deliberate root rotation or a substituted key.
     const replyKeyChanged = $derived(
         !!publishedReplyKey &&
@@ -41,6 +41,37 @@
         pinnedReplyKey = pinnedManagementReplyKey();
     });
 
+    /**
+     * `/config` is unauthenticated, unlike `/status`, which requires an instance
+     * operator. A team administrator who may perform management writes but is not
+     * an operator would otherwise be blocked by a rotated identity with no way to
+     * see or re-trust the new one.
+     */
+    async function loadReplyIdentity() {
+        if (!user?.pubkey) return;
+        replyIdentityError = null;
+        try {
+            const config = await api.get<{
+                management_reply_public_key?: unknown;
+            }>("/config", { params: { pubkey: user.pubkey } });
+            publishedReplyKey = isManagementReplyKey(
+                config.management_reply_public_key,
+            )
+                ? config.management_reply_public_key
+                : null;
+            if (!publishedReplyKey) {
+                replyIdentityError =
+                    "The signer did not publish a management reply identity.";
+            }
+        } catch (error) {
+            publishedReplyKey = null;
+            replyIdentityError =
+                error instanceof Error
+                    ? error.message
+                    : "Could not load the management reply identity";
+        }
+    }
+
     function trustReplyKey() {
         if (!publishedReplyKey) return;
         trustManagementReplyKey(publishedReplyKey);
@@ -48,8 +79,15 @@
         toast.success("Management reply identity trusted");
     }
 
+    async function refreshAll() {
+        await Promise.all([refresh(), loadReplyIdentity()]);
+    }
+
     $effect(() => {
-        if (user?.pubkey) void refresh();
+        if (user?.pubkey) {
+            void refresh();
+            void loadReplyIdentity();
+        }
     });
 
     async function refresh() {
@@ -153,7 +191,7 @@
     </div>
     <button
         class="button button-secondary button-icon"
-        onclick={refresh}
+        onclick={refreshAll}
         disabled={isLoading}
     >
         <ArrowClockwise size="20" /> Refresh
@@ -163,6 +201,39 @@
 {#if loadError}<p class="input-error">
         {loadError}. Instance status requires an operator.
     </p>{/if}
+
+<div class="card mb-5" class:border-warning={replyKeyChanged}>
+    <h2 class="text-xl font-bold mb-2">Management reply identity</h2>
+    {#if replyIdentityError}
+        <p class="input-error">{replyIdentityError}</p>
+    {:else}
+        <p class="description">
+            Published by the signer: <code
+                >{publishedReplyKey
+                    ? managementReplyFingerprint(publishedReplyKey)
+                    : "loading"}</code
+            >
+        </p>
+        <p class="description">
+            Trusted by this browser: <code
+                >{pinnedReplyKey
+                    ? managementReplyFingerprint(pinnedReplyKey)
+                    : "nothing pinned yet"}</code
+            >
+        </p>
+    {/if}
+    {#if replyKeyChanged}
+        <p class="text-warning mt-3" role="alert">
+            This identity changed, so management writes are blocked. Run
+            <code>keycast_signer status</code> on your host and compare its
+            <code>management_reply_public_key</code>. Trust the new identity only
+            if you rotated the root credential yourself.
+        </p>
+        <button class="button button-danger mt-3" onclick={trustReplyKey}
+            >Trust this identity</button
+        >
+    {/if}
+</div>
 
 {#if isLoading && !status}
     <Loader />
@@ -259,43 +330,12 @@
         {/each}
     </div>
 
-    {#if replyKeyChanged}
-        <div class="card mb-5" role="alert">
-            <h2 class="text-xl font-bold mb-3 text-warning">
-                Management reply identity changed
-            </h2>
-            <p class="description mb-3">
-                This browser pinned <code
-                    >{managementReplyFingerprint(pinnedReplyKey ?? "")}</code
-                >
-                but the signer now publishes
-                <code>{managementReplyFingerprint(publishedReplyKey ?? "")}</code
-                >. Management writes stay blocked until this is resolved.
-            </p>
-            <p class="description mb-3">
-                Run <code>keycast_signer status</code> on your host and compare
-                its <code>management_reply_public_key</code>. Trust the new
-                identity only if you rotated the root credential yourself.
-            </p>
-            <button class="button button-danger" onclick={trustReplyKey}
-                >Trust this identity</button
-            >
-        </div>
-    {/if}
-
     <div class="card mb-5">
         <h2 class="text-xl font-bold mb-3">Diagnostics</h2>
         <div class="grid sm:grid-cols-2 gap-2 text-sm text-muted">
             <p>
                 Credential fingerprint: <code
                     >{status.signer.credential_key_id ?? "unavailable"}</code
-                >
-            </p>
-            <p>
-                Management reply identity: <code
-                    >{publishedReplyKey
-                        ? managementReplyFingerprint(publishedReplyKey)
-                        : "unavailable"}</code
                 >
             </p>
             <p>Denied requests: {status.signer.denied_requests}</p>


### PR DESCRIPTION
## Summary

Two security review passes covered the signer authorization router, the NIP-46 request pipeline, envelope and backup cryptography, the SvelteKit frontend, and the container, CI and operations layer. This fixes everything they found.

No critical or high-severity issue existed in application code. The one high finding was a deployment default: the shipped reverse-proxy example mounted the Docker socket. The medium findings are an availability weakness in relay admission, unauthenticated management replies, a popup-handling gap in NIP-46 sign-in, and several container and supply-chain defaults.

Full findings, fixes and residual risk are recorded in the second-pass table in `AUDIT.md`.

## Signer and core

- **Never forward a client-supplied event id into `sign_event`.** The nostr crate signs `unsigned.id` before verifying it, so the signer briefly produced a real Schnorr signature over an attacker-chosen 32-byte value. The mismatch was rejected afterwards so nothing escaped, but the property rested entirely on library ordering. The id is now always stripped and recomputed.
- **Split relay admission into two lanes.** A grant's remote-signer key is published in every bunker URI and every client request, so anyone could address forged events to it and exhaust the single shared per-second budget, starving signing for every grant. Clients with a live session on the target grant now draw from an established lane; everything else, including `connect`, uses a smaller newcomer lane that cannot exhaust it. The live-session index refreshes with the grant configuration.
- **Authenticate management write replies.** They were encrypted to a fresh per-reply key, leaving NIP-44 with nothing to prove the sender, so anyone on path (including the untrusted API) could forge an outcome such as a `bunker://` URI pointing at their own signer. The signer now derives a stable reply identity from the root credential and publishes its public half through `/config`.
- **Fix `DELETE /teams/{id}`,** which could never succeed once a team had any grant: `grants` references `policies` with `ON DELETE RESTRICT` while `policies` cascades from `teams`, and revocation is a tombstone rather than a row delete.
- Add a `Secret` newtype that erases its buffer and redacts `Debug`, stop cloning the lifecycle request, refuse any approval whose content would carry private key material, and require the backup key to differ from the root credential.

## Web

- Require `https` and open with `noopener` for a signer-supplied `auth_url`, and set `Cross-Origin-Opener-Policy`. A malicious handshake relay could otherwise race an `ack`, become the remote signer, and navigate the operator's tab to a look-alike page mid sign-in.
- Pin the reply identity, decrypt only with the pinned key, and fail closed on a change, with the fingerprint shown on the Status page for comparison against the host.
- Narrow CSP to `'self'` and `wss:`, remove an unused follows fetch that announced the operator's pubkey and address to five public relays on every signed-in page load, stop following relay hints from fetched events, and validate the `[pubkey]` route parameter before it reaches a signed request.

## Deployment

- **Replace the Docker socket mount in the proxy example with a static Caddyfile.** Read-only applies to the socket file, not to the Docker API sent over it, so code execution in the only Internet-facing process was root-equivalent on the host. The VM deployment already ran a static config, so the shipped example was weaker than reality.
- Make the ingress network internal, give the signer its own egress network, disable container swap so decrypted key material cannot be paged to host swap, and harden tmpfs flags and image ownership.
- Rewrite `.dockerignore` in allowlist form. Root-anchored patterns let the `legacy-v1/master.key` that `UPGRADE.md` instructs the operator to create into the build context.
- Pin every action to a commit SHA, add Dependabot, build with provenance and an SBOM, attest the images, guard publishing to `master`, and verify provenance in the preflight rather than calling a digest "reviewed".
- Harden the systemd templates, and make the preflight integrity check read-only and ordered before the ownership repair.

## Reviewer notes

**One reported finding was not reproduced and is intentionally unchanged.** Discovered relays do not bypass the SSRF vetting. `runtime.rs` places every discovered relay into a restricted set and the custom transport in `relay_transport.rs` routes those connections through `public_relay::connect`, which re-resolves and re-validates every DNS answer on each connect and refuses proxies. There is no DNS-rebind window.

**Deliberate non-change:** the API and signer still share UID 10001. The socket permission fallback for filesystems that reject `chmod` on a Unix socket depends on that, and the API has no writable mount, so splitting the UID would risk a working deployment for no real gain. This and four other residuals (browser-import buffers, proxy-masked peer IP, replayable 60-second read tokens, the `ca-certificates` layer) are recorded in `AUDIT.md`.

**Breaking for existing deployments.** The `keycast` network must be recreated as internal and the proxy switches to the static file. Both steps are in the new "Hardening migration" section of `UPGRADE.md`. After a root-credential rotation the reply identity changes; the Status page shows both fingerprints and a button to trust the new one.

## Testing

| Check | Result |
|---|---|
| `cargo fmt --all --check`, `cargo check --workspace --locked` | clean |
| `cargo test --workspace --locked` | 103 passed, 0 failed |
| `cargo audit` | no advisories |
| `python3 -m unittest discover -s scripts/operations` | passed |
| `bun run check`, `bun test`, `bun run build` (web) | 0 errors, 57 passed |
| `bun audit`, `bun pm scan`, `bun pm untrusted` | clean |
| All three Compose files render; all three images build | passed |
| `scripts/container-smoke.sh` | passed |

Both regressions were confirmed to **fail before the fix**, not merely pass after:

- Reverting the admission lane split makes the new end-to-end test time out, showing an established client's request dropped under a forged flood.
- The team-delete constraint failure was reproduced against the real migrations in sqlite before changing the handler.

New coverage: an end-to-end starvation test through the production runtime, the stable reply identity end to end, the approval content guard, team delete with live and revoked grants, reply-identity pinning, and the stripped event id. The container smoke test gained assertions for the pinned reply identity, the approval guard and team delete. The build context was verified by building it with planted decoy secrets in every path a denylist would have missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added management-reply identity verification, browser pinning, and status fingerprints.
  - Improved protection for private-key imports, approval content, remote signer links, and sensitive request data.
  - Strengthened content security policies, request validation, and container isolation.

- **Deployment**
  - Added static reverse-proxy configuration, external state-directory support, and hardened Docker networking and filesystem settings.
  - Added image provenance, digest verification, and upgrade preflight checks.

- **Bug Fixes**
  - Team deletion now removes associated access and pending requests.
  - Invalid public keys and forged event identifiers are rejected.
  - Established relay sessions are protected from newcomer floods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->